### PR TITLE
Use relative paths for vite support

### DIFF
--- a/packages/serp-report/src/pages/iframe/index.html
+++ b/packages/serp-report/src/pages/iframe/index.html
@@ -9,8 +9,8 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <meta content="utf-8" http-equiv="encoding" />
     <link rel="stylesheet" href="../../../../ui/src/styles/reset.css" />
-    <script type="module" src="wtm-report.js"></script>
-    <script type="module" src="resize-popup.js"></script>
+    <script type="module" src="./wtm-report.js"></script>
+    <script type="module" src="./resize-popup.js"></script>
   </head>
   <body>
     <wtm-report></wtm-report>


### PR DESCRIPTION
No braking change, only changed URLs in serp-report iframe HTML to be relative.