### PR TITLE
fix: account for message.data any type

### DIFF
--- a/packages/serp-report/src/content_scripts/serp-report.js
+++ b/packages/serp-report/src/content_scripts/serp-report.js
@@ -184,7 +184,10 @@ function removeWheel(anchor) {
         return;
       }
 
-      if (message.data.startsWith('WTMReportResize')) {
+      if (
+        typeof message.data === 'string' &&
+        message.data.startsWith('WTMReportResize')
+      ) {
         const height = message.data.split(':')[1];
         resizePopup(height);
         return;


### PR DESCRIPTION
Addresses #19. Simple check that the `String` prototype functions are available before referencing them.