### PR TITLE
Add missing dexie dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/anonymous-communication"
       ],
       "dependencies": {
+        "dexie": "^3.2.1",
         "pako": "^2.0.4"
       },
       "devDependencies": {
@@ -10611,7 +10612,7 @@
       "requires": {
         "@rollup/plugin-node-resolve": "^13.1.3",
         "chai": "^4.3.6",
-        "dexie": "*",
+        "dexie": "^3.2.1",
         "fast-check": "^2.23.2",
         "karma": "^6.3.17",
         "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "packages/anonymous-communication"
   ],
   "dependencies": {
+    "dexie": "^3.2.1",
     "pako": "^2.0.4"
   }
 }


### PR DESCRIPTION
For now, we are installing all packages, so we need to add the dependency of the package to the main `package.json`. The `dexie` was missing but it is used by the `anonymous-communication` package.