### PR TITLE
Prefer code over JSON.parse for tracker-preview data

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 packages/**/*.bundle.js
+packages/**/trackers-preview-generated.js
 packages/**/scripts/**/*.js

--- a/packages/trackers-preview/scripts/download.js
+++ b/packages/trackers-preview/scripts/download.js
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 
 const DATA_URL = 'https://whotracks.me/data/trackers-preview.json';
 const OUTPUT_FILE = new URL(
-  '../src/background/trackers-preview.json',
+  '../src/background/trackers-preview-generated.js',
   import.meta.url,
 ).pathname;
 
@@ -14,7 +14,7 @@ const data = await fetch(DATA_URL).then((res) => {
   return res.text();
 });
 
-writeFileSync(OUTPUT_FILE, data);
+writeFileSync(OUTPUT_FILE, `export default ${data}`);
 
 console.log(
   `Trackers preview data downloaded and saved in "${OUTPUT_FILE.replace(

--- a/packages/trackers-preview/src/background/index.js
+++ b/packages/trackers-preview/src/background/index.js
@@ -10,7 +10,7 @@
  */
 import { parse } from 'tldts-experimental';
 
-import trackersPreview from './trackers-preview.json';
+import trackersPreview from './trackers-preview-generated';
 
 /**
  * Takes a site (e.g. "economist.com") and returns a map of categories


### PR DESCRIPTION
Avoid parsing the trackers-preview-data on each startup. Instead ship it as JavaScript code, you allow the JavaScript engine to cache its bytecode.

JSON.parse is generally faster for dynamic data, but since the trackers-preview is hard-coded, representing it as code allows caching of the parsed bytecode if JavaScript engines support it.