### PR TITLE
Integrate reporting in Ghostery (Manifest V3)

### DIFF
--- a/packages/anonymous-communication/src/errors.js
+++ b/packages/anonymous-communication/src/errors.js
@@ -9,6 +9,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+/**
+ * The base class to cover all expected error situations in
+ * anonymous-communication; errors are either recoverable
+ * (RecoverableError) or permanent (PermanentError). Clients
+ * can use this information to implement their own error recovery.
+ *
+ * Note: anonymous-communication will not wrap unexpected errors.
+ * If you see one, it is a strong indicator that there is a bug
+ * in the code (e.g. configuration errors, incorrect use of the API).
+ */
 class ExtendableError extends Error {
   constructor(message) {
     super(message);
@@ -21,6 +31,29 @@ class ExtendableError extends Error {
   }
 }
 
+/**
+ * Serves as a hint that retrying the failed operation later
+ * is a reasonable error-recovery strategy.
+ *
+ * Even for recoverable errors, retrying immediately is almost
+ * never a good idea. When you get an error, it means that
+ * anonymous-communication exhausted the basic error recovery options.
+ *
+ * What does "basic error recovery" mean? annonymous-communications
+ * intends to provide a reliable channel, but at some time being
+ * agnostic of the semantics of messages.
+ *
+ * Two illustrate the fine line of responsibilities, let us
+ * look at two examples:
+ *
+ * 1) the network times out when sending one message (same if
+ *    the server fails to respond): here anonymous-credentials
+ *    can transparently attempt to send it again after a few seconds.
+ * 2) the network is down for extended period (e.g. on mobile)
+ *    and failed messages are queing up: here it is the responsibly
+ *    of the client to decide whether older message should be dropped,
+ *    retried at a later point, or replaced by updated messages.
+ */
 class RecoverableError extends ExtendableError {
   constructor(message) {
     super(message);
@@ -29,6 +62,13 @@ class RecoverableError extends ExtendableError {
   }
 }
 
+/**
+ * Thrown if an operation failed and it is guaranteed that
+ * retrying it will result in the identical error.
+ *
+ * For example, if a message was rejected since it was is too big,
+ * trying to send it again will again trigger the identical error.
+ */
 class PermanentError extends ExtendableError {
   constructor(message) {
     super(message);
@@ -41,4 +81,4 @@ export class TooBigMsgError extends PermanentError {}
 export class TransportError extends RecoverableError {}
 export class ProtocolError extends PermanentError {}
 export class InvalidMessageError extends PermanentError {}
-export class ModuleDisabled extends RecoverableError {}
+export class ClockOutOfSync extends RecoverableError {}

--- a/packages/anonymous-communication/src/trusted-clock.js
+++ b/packages/anonymous-communication/src/trusted-clock.js
@@ -1,0 +1,58 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { ClockOutOfSync } from './errors.js';
+
+/**
+ * Contains functions to generate timestamps used in WhoTracksMe messages.
+ * As a general rule, all timestamps in the context of WhoTracksMe will be in UTC.
+ *
+ * To mitigate the risk of fingerprinting based on clock drift, messages
+ * should not include high resolution timestamps, but instead should be truncated.
+ */
+export class TrustedClock {
+  checkTime() {
+    // TODO: Trust that the local system time is correct. On most systems,
+    // that assumption should hold. it is a non-trivial problem to improve
+    // it under Manifest V3 constraints (ideas like running a parallel
+    // clock with setTimeout/setInterval is not a solution because of the
+    // lack of persistent background page; the alarm API is too imprecise;
+    // maybe a reliable clock could be built by observing server time-stamps).
+    return {
+      inSync: true,
+      unixEpoche: Date.now(),
+    };
+  }
+
+  now() {
+    const { inSync, unixEpoche } = this.checkTime();
+    if (!inSync) {
+      throw new ClockOutOfSync();
+    }
+    return unixEpoche;
+  }
+
+  getTimeAsYYYYMMDD(now) {
+    const ts = now ?? this.now();
+    return new Date(ts)
+      .toISOString()
+      .replace(/[^0-9]/g, '')
+      .slice(0, 8);
+  }
+
+  getTimeAsYYYYMMDDHH(now) {
+    const ts = now ?? this.now();
+    return new Date(ts)
+      .toISOString()
+      .replace(/[^0-9]/g, '')
+      .slice(0, 10);
+  }
+}

--- a/packages/anonymous-communication/src/utils.js
+++ b/packages/anonymous-communication/src/utils.js
@@ -1,0 +1,28 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+/**
+ * Use case: when running object through JSON.stringify, it
+ * should not be distinguishable in which order the object keys
+ * where added.
+ *
+ * Note: The current implement only operates on the first level.
+ * In our context, that should be suffient, since
+ * anonymous-communication will not add nested structures.
+ * The only nested structure is the payload, which means the
+ * message creator will be responsible for the ordering.
+ *
+ * Should that become a burden, we could extend this function
+ * to recursively sort the object keys.
+ */
+export function sortObjectKeys(obj) {
+  return Object.fromEntries(Object.entries(obj).sort());
+}

--- a/packages/anonymous-communication/test/utils.spec.js
+++ b/packages/anonymous-communication/test/utils.spec.js
@@ -1,0 +1,43 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import * as fc from 'fast-check';
+import { expect } from 'chai';
+import { sortObjectKeys } from '../src/utils.js';
+
+describe('#sortObjectKeys', function () {
+  it('should ignore the creation order of keys', function () {
+    const obj1 = {
+      one: 'eins',
+      two: 'zwei',
+      three: 'drei',
+    };
+    const obj2 = {
+      two: 'zwei',
+      three: 'drei',
+      one: 'eins',
+    };
+
+    const obj1Json = JSON.stringify(sortObjectKeys(obj1));
+    const obj2Json = JSON.stringify(sortObjectKeys(obj2));
+    expect(obj1Json).to.eql(obj2Json);
+  });
+
+  it('should be idempotent', function () {
+    fc.assert(
+      fc.property(fc.object(), (obj) => {
+        const once = sortObjectKeys(obj);
+        const twice = sortObjectKeys(once);
+        expect(JSON.stringify(once)).to.eql(JSON.stringify(twice));
+      }),
+    );
+  });
+});

--- a/packages/reporting/example/index.js
+++ b/packages/reporting/example/index.js
@@ -41,9 +41,9 @@ const reporting = new Reporting({
 
 (async function () {
   await reporting.init();
-  reporting.patterns.updatePatterns(rules);
+  await reporting.patterns.updatePatterns(rules);
   reporting.sanitizer.setSafeCountryCode('de');
-  reporting.analyzeUrl('https://www.google.com/search?q=shoes');
+  await reporting.analyzeUrl('https://www.google.com/search?q=shoes');
   await reporting.processPendingJobs();
 })();
 

--- a/packages/reporting/src/alive-check.js
+++ b/packages/reporting/src/alive-check.js
@@ -1,0 +1,132 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import logger from './logger';
+
+const HOUR = 1000 * 60 * 60;
+
+/**
+ * Responsible for sending "alive" messages. Alive messages exist
+ * to monitor whether the client side of WhoTracks.me reporting
+ * is healthy.
+ *
+ * By separating alive messages from more sensitive messages (e.g.
+ * one that may contain a URL), we can include additional information
+ * (like the browser) without risking to introduce fingerprinting.
+ * Given that there is a correlation between the number of sent
+ * "alive" messages and the number of other messages that enables us
+ * to detect scenerios like a message drop after a browser release.
+ *
+ * Note that putting information like the browser directly inside
+ * all (non-alive) messages would solve the monitoring problem
+ * but at the cost of potentially introducing fingerprinting.
+ * Separating monitoring (alive) and other messages limits the
+ * risk: even if you could link "alive" messages, they do not
+ * contain sensitive information.
+ */
+export default class AliveCheck {
+  constructor({
+    communication,
+    countryProvider,
+    trustedClock,
+    storage,
+    storageKey,
+  }) {
+    this.communication = communication;
+    this.countryProvider = countryProvider;
+    this.trustedClock = trustedClock;
+    this.storage = storage;
+    this.storageKey = storageKey;
+    this._skipChecksUntil = 0; // Unix timestamp
+  }
+
+  /**
+   * Guaranteed to finish fast and never fail. Callers can safely execute it from
+   * at any place. Since "alive" messages should correlate with activity, this
+   * should be called from places like page visits (triggered by human interaction).
+   *
+   * What counts as "activity" is currently not specified. A vague definition is
+   * that if a user keeps actively using the browser, it should trigger an "alive"
+   * message eventually; but if there is no user interaction and the device is idle,
+   * it should eventually stop sending signals.
+   */
+  ping(now = Date.now()) {
+    this._check(now).catch((e) => {
+      logger.warn('Error while processing alive checks', e);
+    });
+  }
+
+  async _check(now = Date.now()) {
+    if (this._pendingUpdate || now < this._skipChecksUntil) {
+      return;
+    }
+
+    this._pendingUpdate = (async () => {
+      try {
+        logger.debug('Checking whether a hourly ping should be sent...');
+        const lastSent = await this.storage.get(this.storageKey);
+
+        const updateSentAt = () =>
+          this.storage.set(this.storageKey, { sentAt: now });
+
+        if (!lastSent) {
+          logger.info(
+            'Last alive check not found. This should only happen on the first time the extension is started.',
+          );
+          await updateSentAt();
+          return;
+        } else if (lastSent.sentAt > now) {
+          const now_ = new Date(now);
+          const sentAt_ = new Date(lastSent.sentAt);
+          logger.warn(
+            `Clock jump detected (now=${now_} but sentAt=${sentAt_} is in the future). Resetting counter.`,
+          );
+          await updateSentAt();
+          return;
+        } else if (lastSent.sentAt + HOUR > now) {
+          logger.debug(
+            'Checking whether a hourly ping should be sent... No reached yet.',
+          );
+          this._skipChecksUntil = lastSent.sentAt + HOUR;
+          return;
+        }
+
+        logger.debug('Hourly ping reached. Sending...');
+        await this._reportAlive();
+        this._skipChecksUntil = now + HOUR;
+        logger.debug('Hourly ping successfully sent. Saving state...');
+        await updateSentAt();
+        logger.debug('Hourly ping succeeded.');
+      } finally {
+        this._pendingUpdate = null;
+      }
+    })();
+    await this._pendingUpdate;
+  }
+
+  async _reportAlive() {
+    // TODO: here we start with a minimal message. In a later step,
+    // we should include information about the browser. When we add
+    // more fields here, best be conservative and add a check for
+    // quorum. since the message is minimal hour+country, we don't
+    // need that extra step for now.
+    const message = {
+      action: 'wtm.alive',
+      ver: 1,
+      payload: {
+        t: this.trustedClock.getTimeAsYYYYMMDDHH(),
+        ctry: this.countryProvider.getSafeCountryCode(),
+      },
+    };
+    logger.debug('Sending alive:', message);
+    await this.communication.send(message);
+  }
+}

--- a/packages/reporting/src/country-provider.js
+++ b/packages/reporting/src/country-provider.js
@@ -38,7 +38,7 @@ const DB_VERSION = 1;
  * (see the comments in "_sanitizeCountry" for details).
  */
 export default class CountryProvider {
-  constructor({ config, storage, storageKey, _fetchImpl }) {
+  constructor({ config, storage, storageKey }) {
     this.allowedCountryCodes = config.ALLOWED_COUNTRY_CODES;
     if (!this.allowedCountryCodes) {
       throw new Error('config.ALLOWED_COUNTRY_CODES not set');
@@ -57,15 +57,6 @@ export default class CountryProvider {
       min: 22 * HOUR,
       max: 26 * HOUR,
     };
-
-    // Wrap browser APIs (primarily to swap them out in the unit tests):
-    // this._fetch works like the native "fetch".
-    //
-    // Notes:
-    // * will not work in NodeJs < 18, since trying to access "fetch" will throw
-    // * the extra argument wrapping was needed on Android (when simplify test
-    //   whether it is still needed in the Ghostery Android Browser)
-    this._fetch = _fetchImpl || ((...args) => fetch(...args));
   }
 
   async init({ now = Date.now() } = {}) {
@@ -149,7 +140,7 @@ export default class CountryProvider {
       try {
         const url = this.configApiEndpoint;
         try {
-          const response = await this._fetch(url, {
+          const response = await fetch(url, {
             method: 'GET',
             cache: 'no-cache',
             credentials: 'omit',

--- a/packages/reporting/src/country-provider.js
+++ b/packages/reporting/src/country-provider.js
@@ -1,0 +1,304 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import logger from './logger';
+import { randBetween, clamp } from './utils';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * If you need to introduce incompatible changes to the the state
+ * persistence, you can bump this number to clear the persisted cache.
+ * It will be as if you start with a fresh installation of the extension.
+ *
+ * (If you are not sure whether the change is incompatible, it is
+ * a good idea to be conservative and bump this number anyway; it will
+ * only introduce little overhead.)
+ */
+const DB_VERSION = 1;
+
+/**
+ * Responsible for fetching the country information from the config API endpoint
+ * and keeping it up-to-date. Although you can force updates through the "update",
+ * it should not be needed to explicitly call it.
+ *
+ * WARNING: When using this class, only access data through the "getSafeCountryCode"
+ * function. Why? Because otherwise, it is easy to accidentially allow fingerprinting
+ * (see the comments in "_sanitizeCountry" for details).
+ */
+export default class CountryProvider {
+  constructor({ config, storage, storageKey, _fetchImpl }) {
+    this.allowedCountryCodes = config.ALLOWED_COUNTRY_CODES;
+    if (!this.allowedCountryCodes) {
+      throw new Error('config.ALLOWED_COUNTRY_CODES not set');
+    }
+    this.configApiEndpoint = config.CONFIG_URL;
+    if (!this.configApiEndpoint) {
+      throw new Error('config.CONFIG_URL not set');
+    }
+    this.storage = storage;
+    this.storageKey = storageKey;
+    this.ctryInfo = null; // guaranteed to exist after "init()"
+
+    // This would result in approximately one request per day
+    // (not counting retry attempts if there were errors).
+    this.cacheExpiration = {
+      min: 22 * HOUR,
+      max: 26 * HOUR,
+    };
+
+    // Wrap browser APIs (primarily to swap them out in the unit tests):
+    // this._fetch works like the native "fetch".
+    //
+    // Notes:
+    // * will not work in NodeJs < 18, since trying to access "fetch" will throw
+    // * the extra argument wrapping was needed on Android (when simplify test
+    //   whether it is still needed in the Ghostery Android Browser)
+    this._fetch = _fetchImpl || ((...args) => fetch(...args));
+  }
+
+  async init({ now = Date.now() } = {}) {
+    if (this.ctryInfo) {
+      logger.debug('CountryProvider is already initialized');
+      return;
+    }
+
+    try {
+      const cachedEntry = await this.storage.get(this.storageKey);
+      if (cachedEntry) {
+        this.ctryInfo = this._validateCtryInfo(cachedEntry, now);
+        this._nonBlockingUpdateInBackground(now);
+        return;
+      }
+    } catch (e) {
+      logger.warn('Failed to get a value from cache', e);
+    }
+
+    // This is a rare situation. Typically, it can be reached only once in a fresh
+    // installation, through schema updates, or in exceptional error situations
+    // where corrupted data was persisted. Since the cache is empty, we will now do
+    // a blocking update to start with a reliable country value.
+    logger.info(
+      'Country information not cached. This should only happen on the first time the extension is started.',
+    );
+    this.ctryInfo = {
+      dbVersion: DB_VERSION,
+      unsafeCtryFromApi: '--',
+      safeCtry: '--',
+      lastSuccessAt: 0, // Unix timestamp
+      lastAttemptAt: 0, // Unix timestamp
+      skipAttemptsUntil: 0, // Unix timestamp
+      failedAttemptsInARows: 0,
+    };
+    try {
+      await this.update({ now });
+    } catch (e) {
+      logger.warn('Unable to get country information. Falling back to "--"', e);
+    }
+  }
+
+  getSafeCountryCode({ skipUpdate = false, now = Date.now() } = {}) {
+    if (!this.ctryInfo) {
+      throw new Error('Illegal state: forgot to call init()');
+    }
+    if (!skipUpdate) {
+      // Schedule an update if needed. That is done to guarantee that updates
+      // will run from time to time. In Manifest V3, this is mostly theoretical,
+      // since service workers will die quickly and "init()" calls also trigger
+      // updates. Nevertheless, there is no downsize of including the update
+      // check here as well.
+      //
+      // Note: It is clear that the update here will at best affect the next call of
+      // "getSafeCountryCode" (even that is not/ guaranteed though). In the rare case
+      // that you need to ensure that an update finished, the caller should instead
+      // explicitly trigger an update ("await countryProvider.update()") before
+      // calling "getSafeCountryCode".
+      this._nonBlockingUpdateInBackground(now);
+    }
+    return this.ctryInfo.safeCtry;
+  }
+
+  /**
+   * Normally, it should not be needed to call this function directly.
+   *
+   * It is safe though to call it in a loop if needed. Multiple calls
+   * will not lead to multiple HTTP requests and the performance impact
+   * should not be noticeable in most scenarios.
+   */
+  async update({ force = false, now = Date.now() } = {}) {
+    if (this._pendingUpdate) {
+      logger.debug('update already in progress...');
+      await this._pendingUpdate;
+      return;
+    }
+    if (!force && now < this.ctryInfo.skipAttemptsUntil) {
+      return;
+    }
+    this._pendingUpdate = (async () => {
+      try {
+        const url = this.configApiEndpoint;
+        try {
+          const response = await this._fetch(url, {
+            method: 'GET',
+            cache: 'no-cache',
+            credentials: 'omit',
+          });
+          if (!response.ok) {
+            throw new Error(`Failed to reach ${url}: ${response.statusText}`);
+          }
+          const { location } = await response.json();
+          const cooldown = randBetween(
+            this.cacheExpiration.min,
+            this.cacheExpiration.max,
+          );
+          this.ctryInfo = this._validateCtryInfo(
+            {
+              dbVersion: DB_VERSION,
+              unsafeCtryFromApi: location,
+              safeCtry: this._sanitizeCountry(location),
+              lastSuccessAt: now,
+              lastAttemptAt: now,
+              skipAttemptsUntil: now + cooldown,
+              failedAttemptsInARows: 0,
+            },
+            now,
+          );
+          logger.debug('Updated country information:', this.ctryInfo);
+        } catch (e) {
+          const failedAttemptsInARows = this.ctryInfo.failedAttemptsInARows + 1;
+          const avgCooldown = failedAttemptsInARows * (30 * SECOND);
+          const noisyCooldown = randBetween(
+            avgCooldown / 1.5,
+            1.5 * avgCooldown,
+          );
+          const cooldown = clamp({
+            value: noisyCooldown,
+            min: 3 * SECOND,
+            max: 3 * DAY,
+          });
+          this.ctryInfo = {
+            ...this.ctryInfo,
+            failedAttemptsInARows,
+            skipAttemptsUntil: now + cooldown,
+          };
+          logger.warn(
+            'Failed to update country. Cooldown until:',
+            new Date(this.ctryInfo.skipAttemptsUntil),
+            e,
+          );
+          throw e;
+        }
+      } finally {
+        await this._syncCacheToDisk();
+        this._pendingUpdate = null;
+      }
+    })();
+    await this._pendingUpdate;
+  }
+
+  _nonBlockingUpdateInBackground(now = Date.now()) {
+    this.update({ now }).catch((e) => {
+      logger.debug(
+        `Unable to update country (${e}). Continuing with existing settings:`,
+        this.ctryInfo,
+      );
+    });
+  }
+
+  async _syncCacheToDisk() {
+    try {
+      await this.storage.set(this.storageKey, this.ctryInfo);
+    } catch (e) {
+      logger.error('Unable to update cache:', this.storageKey, e);
+    }
+  }
+
+  /**
+   * As long as there are enough other users, revealing the country
+   * will not compromise anonymity. Only if the user base is too low
+   * (e.g., Liechtenstein), we have to be careful. In that case,
+   * do not reveal the country, otherwise fingerprinting attacks
+   * could be possible.
+   *
+   * The server side will already hide countries with few users.
+   * But as the expected number of users varies between products,
+   * the client can additionally filter the list further (the
+   * information for it is provided by the config).
+   *
+   * Including the unmodified country (without sanitizing) in messages,
+   * is also not recommended, since it would allow fingerprinting attacks
+   * should an attacker get control of the server: The attacker could modify
+   * the API to return unique identifiers instead of the country. If the
+   * client would include these ID in messages, the server could then link
+   * messages from the same user.
+   */
+  _sanitizeCountry(ctry) {
+    return this.allowedCountryCodes.includes(ctry) ? ctry : '--';
+  }
+
+  /**
+   * Runs some sanity checks on the data. You can use it to reject corrupted
+   * data that has been fetch from the API, or has been loaded from the storage.
+   *
+   * If this function throws, the new value will be dropped. If available,
+   * the client will continue to the last good value; otherwise, it will
+   * fallback to "--".
+   */
+  _validateCtryInfo(ctryInfo, now) {
+    const {
+      dbVersion,
+      unsafeCtryFromApi,
+      safeCtry,
+      lastSuccessAt,
+      lastAttemptAt,
+      skipAttemptsUntil,
+    } = ctryInfo;
+
+    if (dbVersion !== DB_VERSION) {
+      throw new Error(
+        `Data schema changed (expected: ${DB_VERSION}, but got ${dbVersion})`,
+      );
+    }
+
+    // Normally countries are something like "us", "de", "fr".
+    // Clients should refuse to store long strings. Though client-side
+    // filtering through the ALLOWED_COUNTRY_CODES list will prevent
+    // fingerprinting attacks from a malicious server, rejecting still
+    // makes sense; most likely it is a bug in the server and
+    // continuing with the previous confirmed value is arguably better.
+    const checkCtry = (ctry) => {
+      if (typeof ctry !== 'string' || !ctry || ctry.length > 4) {
+        const msg = `Rejecting data with corrupted country: ${ctry}`;
+        logger.warn(msg, ctryInfo);
+        throw new Error(msg);
+      }
+    };
+    checkCtry(unsafeCtryFromApi);
+    checkCtry(safeCtry);
+
+    // If we see timestamps that are in the future, or the
+    // cooldowns that will prevent updates for months,
+    // we should drop the data to force a reset.
+    if (
+      lastSuccessAt > now + 5 * MINUTE ||
+      lastAttemptAt > now + 5 * MINUTE ||
+      skipAttemptsUntil > now + 90 * DAY
+    ) {
+      const msg = 'Rejecting data with corrupted timestamps';
+      logger.warn(msg, ctryInfo);
+      throw new Error(msg);
+    }
+    return ctryInfo;
+  }
+}

--- a/packages/reporting/src/duplicate-detector.js
+++ b/packages/reporting/src/duplicate-detector.js
@@ -162,12 +162,16 @@ export function computeDeduplicationKey({ body, deduplicateBy = '' }) {
 export default class DuplicateDetector {
   constructor(persistedHashes) {
     this.persistedHashes = persistedHashes;
-    this.unloaded = false;
+    this.enabled = false;
+  }
+
+  async init() {
+    this.enabled = true;
   }
 
   unload() {
-    if (!this.unloaded) {
-      this.unloaded = true;
+    if (this.enabled) {
+      this.enabled = false;
       this.persistedHashes.flush();
     }
   }
@@ -180,10 +184,10 @@ export default class DuplicateDetector {
    * cannot retry, as all later attempts will be rejected as duplicates.
    */
   async trySend(message) {
-    if (this.unloaded) {
+    if (!this.enabled) {
       return {
         ok: false,
-        rejectReason: 'Module is unloading',
+        rejectReason: 'Module is disabled',
       };
     }
 

--- a/packages/reporting/src/patterns-updater.js
+++ b/packages/reporting/src/patterns-updater.js
@@ -39,7 +39,7 @@ const DB_VERSION = 1;
  * within the configured intervals.
  */
 export default class PatternsUpdater {
-  constructor({ config, patterns, storage, storageKey, _fetchImpl }) {
+  constructor({ config, patterns, storage, storageKey }) {
     this.patterns = patterns;
     this.storage = storage;
     this.storageKey = storageKey;
@@ -68,15 +68,6 @@ export default class PatternsUpdater {
       max: 2 * HOUR,
     };
     this._initEmptyCache();
-
-    // Wrap browser APIs (primarily to swap them out in the unit tests):
-    // this._fetch works like the native "fetch".
-    //
-    // Notes:
-    // * will not work in NodeJs < 18, since trying to access "fetch" will throw
-    // * the extra argument wrapping was needed on Android (when simplify test
-    //   whether it is still needed in the Ghostery Android Browser)
-    this._fetch = _fetchImpl || ((...args) => fetch(...args));
   }
 
   _initEmptyCache() {
@@ -199,7 +190,7 @@ export default class PatternsUpdater {
     });
     try {
       this._persistedState.lastFetchAttempt = now;
-      const response = await this._fetch(url, {
+      const response = await fetch(url, {
         method: 'GET',
         cache: 'no-cache',
         credentials: 'omit',

--- a/packages/reporting/src/reporting.js
+++ b/packages/reporting/src/reporting.js
@@ -23,7 +23,7 @@ import AliveCheck from './alive-check';
 import logger from './logger';
 
 export default class Reporting {
-  constructor({ config, storage, communication, _fetchImpl = null }) {
+  constructor({ config, storage, communication }) {
     // Defines whether Reporting is fully initialized and has permission
     // to collect data.
     this.isActive = false;
@@ -35,13 +35,11 @@ export default class Reporting {
       patterns: this.patterns,
       storage,
       storageKey: 'patterns',
-      _fetchImpl,
     });
     this.countryProvider = new CountryProvider({
       config,
       storage,
       storageKey: 'ctry',
-      _fetchImpl,
     });
     this.sanitizer = new Sanitizer(this.countryProvider);
     this.urlAnalyzer = new UrlAnalyzer(this.patterns);

--- a/packages/reporting/src/sanitizer.js
+++ b/packages/reporting/src/sanitizer.js
@@ -54,7 +54,7 @@ function checkForLongNumber(str, maxNumberLength) {
 }
 
 function isSuspiciousQueryStub(query) {
-  logger.info('[STUB] isSuspiciousQuery is not fully ported.');
+  logger.debug('[STUB] isSuspiciousQuery is not fully ported.');
 
   // Remove the msg if the query is too long,
   if (query.length > 50) {
@@ -224,11 +224,8 @@ export function sanitizeUrl(url) {
  * you will find many harmless examples that will be rejected by the rules.
  */
 export default class Sanitizer {
-  constructor(config) {
-    this.allowedCountryCodes = config.ALLOWED_COUNTRY_CODES;
-    if (!this.allowedCountryCodes) {
-      throw new Error('config.ALLOWED_COUNTRY_CODES not set');
-    }
+  constructor(countryProvider) {
+    this.countryProvider = countryProvider;
   }
 
   isSuspiciousQuery(query) {
@@ -266,21 +263,7 @@ export default class Sanitizer {
     return null;
   }
 
-  /**
-   * As long as there are enough other users, revealing the country
-   * will not compromise anonymity. Only if the user base is too low
-   * (e.g., Liechtenstein), we have to be careful. In that case,
-   * do not reveal the country, otherwise fingerprinting attacks
-   * could be possible.
-   *
-   * As the expected number of users varies between products,
-   * the information needs to be provided by the config.
-   */
   getSafeCountryCode() {
-    return this.allowedCountryCodes.includes(this.ctry) ? this.ctry : '--';
-  }
-
-  setSafeCountryCode(ctry) {
-    this.ctry = ctry;
+    return this.countryProvider.getSafeCountryCode();
   }
 }

--- a/packages/reporting/src/utils.js
+++ b/packages/reporting/src/utils.js
@@ -1,0 +1,18 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+export function randBetween(min, max) {
+  return min + Math.random() * (max - min);
+}
+
+export function clamp({ min, max, value }) {
+  return Math.min(Math.max(min, value), max);
+}

--- a/packages/reporting/test/alive-check.spec.js
+++ b/packages/reporting/test/alive-check.spec.js
@@ -1,0 +1,142 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { expect } from 'chai';
+
+import AliveCheck from '../src/alive-check.js';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('#AliveCheck', function () {
+  const storageKey = 'some-storage-key';
+  let trustedClock;
+  let communication;
+  let countryProvider;
+  let storage;
+  let uut;
+
+  function newAliveCheck() {
+    return new AliveCheck({
+      communication,
+      countryProvider,
+      trustedClock,
+      storage,
+      storageKey,
+    });
+  }
+
+  // Helper that simulate an event like a restart of the service worker/background script:
+  // it keeps the storage but purges everything that was in memory.
+  async function simulateRestart() {
+    uut = newAliveCheck();
+  }
+
+  function expectNoMessageSent() {
+    expect(communication._message).to.be.an('array').that.is.empty;
+    communication._message.length = 0;
+  }
+
+  function expectOneMessageSent() {
+    expect(communication._message).to.be.an('array').that.has.lengthOf(1);
+    communication._message.length = 0;
+  }
+
+  function numMessagesSent() {
+    const count = communication._message.length;
+    communication._message.length = 0;
+    return count;
+  }
+
+  beforeEach(() => {
+    trustedClock = {
+      getTimeAsYYYYMMDDHH: () => '<some timestamp>',
+    };
+    communication = {
+      _message: [],
+      async send(msg) {
+        this._message.push(msg);
+      },
+    };
+    countryProvider = {
+      getSafeCountryCode: () => 'de',
+    };
+    storage = {
+      async get(key) {
+        expect(key).to.equal(storageKey);
+        return this._content;
+      },
+      async set(key, obj) {
+        expect(key).to.equal(storageKey);
+        this._content = obj;
+      },
+    };
+    uut = newAliveCheck();
+  });
+
+  describe('on a fresh extension installation', function () {
+    it('should not immediately send a message', async () => {
+      await uut._check();
+      expectNoMessageSent();
+    });
+
+    it('should eventually send a message (after more then one hour of activity)', async () => {
+      let now = Date.now();
+      for (let i = 0; i < 90; i += 1) {
+        await uut._check(now);
+        now += 1 * MINUTE;
+      }
+      expectOneMessageSent();
+    });
+
+    it('should not send more then one message per hour', async () => {
+      let now = Date.now();
+      for (let i = 0; i < DAY; i += MINUTE) {
+        if (i % 7 === 0) {
+          await simulateRestart();
+        }
+        await uut._check(now);
+        now += 1 * MINUTE;
+      }
+      // underspecify what should happen on the first day
+      expect(numMessagesSent()).to.be.within(22, 24);
+
+      // if we repeat (now the effect of the initial installation is gone),
+      // the semantic is clear: one message per hour over one day -> 24 messages
+      for (let i = 0; i < DAY; i += MINUTE) {
+        if (i % 7 === 0) {
+          await simulateRestart();
+        }
+        await uut._check(now);
+        now += 1 * MINUTE;
+      }
+      expect(numMessagesSent()).to.eql(24);
+    });
+  });
+
+  describe('when multiple check happens at the same time', function () {
+    it('should not result in multiple messages', async () => {
+      let now = Date.now();
+      for (let i = 0; i < DAY; i += MINUTE) {
+        await Promise.all([
+          uut._check(now),
+          uut._check(now),
+          uut._check(now),
+          uut._check(now),
+        ]);
+        expect(numMessagesSent()).to.be.at.most(1);
+        now += MINUTE;
+      }
+    });
+  });
+});

--- a/packages/reporting/test/country-provider.spec.js
+++ b/packages/reporting/test/country-provider.spec.js
@@ -10,6 +10,7 @@
  */
 
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import CountryProvider from '../src/country-provider.js';
 
@@ -67,7 +68,6 @@ describe('#CountryProvider', function () {
       config,
       storage,
       storageKey,
-      _fetchImpl: fetchMock,
     });
   }
 
@@ -99,10 +99,12 @@ describe('#CountryProvider', function () {
       },
     };
     fetchMock = mockApi();
+    sinon.stub(window, 'fetch').callsFake(fetchMock);
     uut = newCountryProvider();
   });
 
   afterEach(() => {
+    window.fetch.restore();
     config = null;
     storage = null;
     fetchMock = null;

--- a/packages/reporting/test/country-provider.spec.js
+++ b/packages/reporting/test/country-provider.spec.js
@@ -1,0 +1,261 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { expect } from 'chai';
+
+import CountryProvider from '../src/country-provider.js';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+// Some big value which should be large enough to
+// make sure all cooldowns have expired.
+const SKIP_ALL_COOLDOWNS = WEEK;
+
+describe('#CountryProvider', function () {
+  const storageKey = 'some-storage-key';
+  const apiEndpoint = 'https://some-endpoint.test';
+  let uut;
+  let config;
+  let storage;
+  let fetchMock;
+
+  function mockApi() {
+    const mock = async (url) => {
+      expect(url).to.eql(apiEndpoint);
+      mock.numRequests += 1;
+      return fetchMock.response();
+    };
+    mock.response = () => new Error('Not configured');
+    mock.numRequests = 0;
+    return mock;
+  }
+
+  function assumeApiReturns(ctry) {
+    fetchMock.response = async () => ({
+      ok: true,
+      async json() {
+        return {
+          location: ctry,
+          'location.city': '--',
+          ts: '20221108',
+        };
+      },
+    });
+  }
+
+  function assumeApiIsDown() {
+    mockApi(async () => ({
+      ok: false,
+      statusText: 'Stub server has been configured to fail (this is expected).',
+    }));
+  }
+
+  function newCountryProvider() {
+    return new CountryProvider({
+      config,
+      storage,
+      storageKey,
+      _fetchImpl: fetchMock,
+    });
+  }
+
+  // Helper that simulate an event like a restart of the service worker/background script:
+  // it keeps the storage but purges everything that was in memory.
+  async function simulateRestart() {
+    uut = newCountryProvider();
+  }
+
+  function expectCountryToBe(expectedCountry) {
+    expect(uut.getSafeCountryCode({ skipUpdate: true })).to.eql(
+      expectedCountry,
+    );
+  }
+
+  beforeEach(() => {
+    config = {
+      CONFIG_URL: apiEndpoint,
+      ALLOWED_COUNTRY_CODES: ['us', 'de', 'fr'],
+    };
+    storage = {
+      async get(key) {
+        expect(key).to.equal(storageKey);
+        return this._content;
+      },
+      async set(key, obj) {
+        expect(key).to.equal(storageKey);
+        this._content = obj;
+      },
+    };
+    fetchMock = mockApi();
+    uut = newCountryProvider();
+  });
+
+  afterEach(() => {
+    config = null;
+    storage = null;
+    fetchMock = null;
+    uut = null;
+  });
+
+  describe('on a fresh extension installation', function () {
+    it('should ask the API for the country', async function () {
+      assumeApiReturns('de');
+      expect(fetchMock.numRequests).to.eql(0);
+      await uut.init();
+      expect(fetchMock.numRequests).to.eql(1);
+      expectCountryToBe('de');
+    });
+
+    it('should fallback to "--" if the API is down', async function () {
+      assumeApiIsDown();
+      await uut.init();
+      expect(fetchMock.numRequests).to.be.greaterThan(0);
+      expectCountryToBe('--');
+    });
+
+    it('should fallback to "--" if the country is not in the client allow-list', async function () {
+      expect(config.ALLOWED_COUNTRY_CODES).to.not.include('aq');
+      assumeApiReturns('aq');
+      await uut.init();
+      expectCountryToBe('--');
+    });
+
+    for (const invalidInput of [
+      'ÄÄ',
+      '',
+      '1234567890',
+      {},
+      '{}',
+      ['foo', 'bar'],
+    ]) {
+      const str = JSON.stringify(invalidInput);
+
+      describe(`when the API returns the invalid country=<<${str}>>`, function () {
+        it('should fallback to "--" if the API returns an unexpected country', async function () {
+          assumeApiReturns(invalidInput);
+          await uut.init();
+          expectCountryToBe('--');
+        });
+      });
+    }
+
+    describe('if the network is initially down', function () {
+      it('should be able to update successfully when the network is back', async function () {
+        assumeApiIsDown();
+        await uut.init();
+        expectCountryToBe('--');
+
+        let failed = false;
+        await uut.update({ force: true }).catch(() => (failed = true));
+        expect(failed).to.eql(true);
+        expectCountryToBe('--');
+
+        assumeApiReturns('de');
+        await uut.update({ force: true });
+        expectCountryToBe('de');
+      });
+
+      it('should later automatically update when network is back', async function () {
+        let now = Date.now();
+        assumeApiIsDown();
+        await uut.init({ now });
+        expectCountryToBe('--');
+
+        // try unsuccessfully for one hour
+        for (let i = 0; i < 60; i += 1) {
+          now += 1 * MINUTE;
+          expect(uut._pendingUpdate).to.not.exist;
+          expect(uut.getSafeCountryCode({ now })).to.eql('--');
+          if (uut._pendingUpdate) {
+            await uut._pendingUpdate.catch(() => {});
+            expect(uut._pendingUpdate).to.not.exist;
+          }
+        }
+        expect(fetchMock.numRequests)
+          .to.be.greaterThan(3)
+          .and.to.be.lessThan(20);
+
+        // network is back
+        assumeApiReturns('de');
+        fetchMock.numRequests = 0;
+
+        // try for the rest of the day
+        for (let i = 0; i < 23 * 60; i += 1) {
+          now += 1 * MINUTE;
+          expect(uut._pendingUpdate).to.not.exist;
+          const ctry = uut.getSafeCountryCode({ now });
+          if (ctry === 'de') {
+            expect(fetchMock.numRequests).to.eql(1);
+            return; // PASSED
+          }
+
+          expect(ctry).to.eql('--');
+          if (uut._pendingUpdate) {
+            await uut._pendingUpdate.catch(() => {});
+            expect(uut._pendingUpdate).to.not.exist;
+          }
+        }
+        expect.fail(
+          'Failed to update within one day, even though it would have worked after one hour',
+        );
+      });
+    });
+  });
+
+  describe('when restarting the extension', function () {
+    const oldValue = 'us';
+    const newValue = 'de';
+    let lastStart;
+
+    beforeEach(async () => {
+      assumeApiReturns(oldValue);
+      lastStart = Date.now();
+
+      expect(fetchMock.numRequests).to.eql(0);
+      await uut.init({ now: lastStart });
+      expect(fetchMock.numRequests).to.eql(1);
+      expectCountryToBe(oldValue);
+
+      fetchMock.numRequests = 0;
+      await simulateRestart();
+      assumeApiReturns(newValue);
+    });
+
+    it('should not immediately fetch the country information', async function () {
+      expect(fetchMock.numRequests).to.eql(0);
+      expect(uut._pendingUpdate).to.not.exist;
+      await uut.init({ now: lastStart + 2 * SECOND });
+
+      expect(uut._pendingUpdate).to.not.exist;
+      expect(fetchMock.numRequests).to.eql(0);
+      expect(uut.getSafeCountryCode({ skipUpdate: true })).to.eql(oldValue);
+    });
+
+    it('should trigger a background update if the country information is too old', async function () {
+      expect(fetchMock.numRequests).to.eql(0);
+      expect(uut._pendingUpdate).to.not.exist;
+      await uut.init({ now: lastStart + SKIP_ALL_COOLDOWNS });
+
+      // wait for the background update to finish
+      const pending = uut._pendingUpdate;
+      expect(pending).to.exist;
+      await pending;
+
+      expect(uut._pendingUpdate).to.not.exist;
+      expect(fetchMock.numRequests).to.eql(1);
+      expectCountryToBe(newValue);
+    });
+  });
+});

--- a/packages/reporting/test/duplicate-detector.spec.js
+++ b/packages/reporting/test/duplicate-detector.spec.js
@@ -52,6 +52,7 @@ describe('#DuplicateDetector', function () {
     });
 
     uut = new DuplicateDetector(persistedHashes);
+    await uut.init();
   });
 
   afterEach(() => {

--- a/packages/reporting/test/index.js
+++ b/packages/reporting/test/index.js
@@ -7,6 +7,7 @@ import 'cssom';
 import './reporting.spec.js';
 import './duplicate-detector.spec.js';
 import './patterns-updater.spec.js';
+import './country-provider.spec.js';
 import './persisted-hashes.spec.js';
 import './url-analyzer.spec.js';
-import './duplicate-detector.spec.js';
+import './alive-check.spec.js';

--- a/packages/reporting/test/patterns-updater.spec.js
+++ b/packages/reporting/test/patterns-updater.spec.js
@@ -10,6 +10,7 @@
  */
 
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import PatternsUpdater from '../src/patterns-updater.js';
 
@@ -181,7 +182,6 @@ describe('#PatternsUpdater', function () {
       patterns: clientPatterns,
       storage,
       storageKey,
-      _fetchImpl: (...args) => fetchMock.fetchImpl(...args),
     });
   }
 
@@ -202,7 +202,12 @@ describe('#PatternsUpdater', function () {
     };
     storage = mockStorage(storageKey);
     fetchMock = mockFetch(config.PATTERNS_URL, serverPatterns);
+    sinon.stub(window, 'fetch').callsFake(fetchMock.fetchImpl);
     uut = newPatternsUpdater();
+  });
+
+  afterEach(function () {
+    window.fetch.restore();
   });
 
   describe('on a fresh extension installation', function () {

--- a/packages/reporting/test/patterns-updater.spec.js
+++ b/packages/reporting/test/patterns-updater.spec.js
@@ -67,6 +67,7 @@ function mockFetch(patternsUrl, serverPatterns) {
     url: patternsUrl,
     options: {
       method: 'GET',
+      cache: 'no-cache',
       credentials: 'omit',
     },
   };
@@ -133,6 +134,7 @@ function mockPatterns() {
 }
 
 describe('#PatternsUpdater', function () {
+  const storageKey = 'some-storage-key';
   let uut;
   let config;
   let storage;
@@ -173,6 +175,22 @@ describe('#PatternsUpdater', function () {
     expect(clientPatterns.getRulesSnapshot()).to.deep.equal(expectedRules);
   }
 
+  function newPatternsUpdater() {
+    return new PatternsUpdater({
+      config,
+      patterns: clientPatterns,
+      storage,
+      storageKey,
+      _fetchImpl: (...args) => fetchMock.fetchImpl(...args),
+    });
+  }
+
+  // Helper that simulate an event like a restart of the service worker/background script:
+  // it keeps the storage but purges everything that was in memory.
+  async function simulateRestart() {
+    uut = newPatternsUpdater();
+  }
+
   beforeEach(function () {
     clientPatterns = mockPatterns();
     serverPatterns = {
@@ -182,16 +200,9 @@ describe('#PatternsUpdater', function () {
     config = {
       PATTERNS_URL: 'https://patterns-location.test',
     };
-    const storageKey = 'some-storage-key';
     storage = mockStorage(storageKey);
     fetchMock = mockFetch(config.PATTERNS_URL, serverPatterns);
-    uut = new PatternsUpdater({
-      config,
-      patterns: clientPatterns,
-      storage,
-      storageKey,
-      _fetchImpl: (...args) => fetchMock.fetchImpl(...args),
-    });
+    uut = newPatternsUpdater();
   });
 
   describe('on a fresh extension installation', function () {
@@ -345,6 +356,40 @@ describe('#PatternsUpdater', function () {
         expectLoadedPatternsToBe(ANOTHER_NON_EMPTY_PATTERN);
         expect(fetchMock.stats.attemptedRequests).to.equal(2);
       });
+    });
+  });
+
+  describe('[after a restart]', function () {
+    it('should not immediately fetch patterns again', async () => {
+      // first make sure the patterns are loaded
+      const now = Date.now();
+      releasePatterns(SOME_NON_EMPTY_PATTERN);
+      await uut.init({ now });
+      expectLoadedPatternsToBe(SOME_NON_EMPTY_PATTERN);
+      expect(fetchMock.stats.attemptedRequests).to.equal(1);
+
+      // If we restart now without letting much time pass, it should
+      // trust the persisted value and save the network calls.
+      await simulateRestart();
+      expect(fetchMock.stats.attemptedRequests).to.equal(1);
+      await uut.init({ now: now + 10 * SECOND });
+      expect(fetchMock.stats.attemptedRequests).to.equal(1);
+    });
+
+    it('should eventually fetch patterns if enough time passed', async () => {
+      // first make sure the patterns are loaded
+      const now = Date.now();
+      releasePatterns(SOME_NON_EMPTY_PATTERN);
+      await uut.init({ now });
+      expectLoadedPatternsToBe(SOME_NON_EMPTY_PATTERN);
+      expect(fetchMock.stats.attemptedRequests).to.equal(1);
+
+      // If we restart now after a longer time, it should not
+      // trust the cached patterns but fetch them from the server.
+      await simulateRestart();
+      expect(fetchMock.stats.attemptedRequests).to.equal(1);
+      await uut.init({ now: now + 4 * WEEK });
+      expect(fetchMock.stats.attemptedRequests).to.equal(2);
     });
   });
 });

--- a/packages/reporting/test/reporting.spec.js
+++ b/packages/reporting/test/reporting.spec.js
@@ -10,6 +10,7 @@
  */
 
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import Reporting from '../src/reporting.js';
 
@@ -30,21 +31,24 @@ describe('#Reporting', function () {
       async send() {},
       trustedClock: {},
     };
-    const _fetchImpl = async (url) => ({
+    sinon.stub(window, 'fetch').callsFake(async (url) => ({
       ok: false,
       statusText: `Stub server has been configured to fail (this is expected): request to ${url}`,
-    });
+    }));
     uut = new Reporting({
       config,
       storage,
       communication,
-      _fetchImpl,
     });
   });
 
   afterEach(function () {
-    uut.unload();
-    uut = null;
+    try {
+      uut.unload();
+      uut = null;
+    } finally {
+      window.fetch.restore();
+    }
   });
 
   describe('should load and unload correctly', function () {

--- a/packages/reporting/test/reporting.spec.js
+++ b/packages/reporting/test/reporting.spec.js
@@ -19,13 +19,27 @@ describe('#Reporting', function () {
   beforeEach(async function () {
     const config = {
       ALLOWED_COUNTRY_CODES: ['us', 'de'],
-      PATTERNS_URL: '',
+      PATTERNS_URL: 'https://some-patterns-endpoint.test',
+      CONFIG_URL: 'https://some-config-endpoint.test',
     };
     const storage = {
       get: () => undefined, // assume nothing was stored yet
       flush: () => {},
     };
-    uut = new Reporting({ config, storage });
+    const communication = {
+      async send() {},
+      trustedClock: {},
+    };
+    const _fetchImpl = async (url) => ({
+      ok: false,
+      statusText: `Stub server has been configured to fail (this is expected): request to ${url}`,
+    });
+    uut = new Reporting({
+      config,
+      storage,
+      communication,
+      _fetchImpl,
+    });
   });
 
   afterEach(function () {


### PR DESCRIPTION
Changes in reporting and anonymous-communication to integrate it in the Ghostery Manifest V3 Extension:
* Move "alive" message and country detection into reporting
* Move the clock to anonymous-communication and make it part of its public interface
* Bug fixes (e.g. problems with caching in the pattern-updater)

refs https://github.com/ghostery/ghostery-extension/pull/934