### PR TITLE
fixed: unload should not throw if it called before the object is initialized

### DIFF
--- a/packages/reporting/src/request-reporter.js
+++ b/packages/reporting/src/request-reporter.js
@@ -60,7 +60,7 @@ export default class RequestReporter {
   }
 
   unload() {
-    if (this.requestMonitor !== null) {
+    if (this.requestMonitor) {
       this.requestMonitor.unload();
       this.requestMonitor = null;
     }


### PR DESCRIPTION
this.requestMonitor starts as undefined, which is !== null.

Fixes:
```
Error while observing options:  TypeError: this.requestMonitor is undefined
    unload moz-extension://711062c7-0b3e-4e88-aa29-a86c29e705aa/node_modules/@whotracksme/webextension-packages/packages/reporting/src/request-reporter.js:66
    setup moz-extension://711062c7-0b3e-4e88-aa29-a86c29e705aa/background/reporting/index.js:152
    wrapper moz-extension://711062c7-0b3e-4e88-aa29-a86c29e705aa/store/options.js:281
    observe moz-extension://711062c7-0b3e-4e88-aa29-a86c29e705aa/store/options.js:293
[options.js:295:13](moz-extension://711062c7-0b3e-4e88-aa29-a86c29e705aa/store/options.js)
    observe moz-extension://711062c7-0b3e-4e88-aa29-a86c29e705aa/store/options.js:295
 ```