### PR TITLE
Only warn once about missing listeners

### DIFF
--- a/packages/reporting/src/webrequest-pipeline/utils/webrequest.js
+++ b/packages/reporting/src/webrequest-pipeline/utils/webrequest.js
@@ -73,9 +73,15 @@ for (const event of Object.keys(EXTRA_INFO_SPEC)) {
   // etc.)
   const extraInfoSpec = EXTRA_INFO_SPEC[event];
 
+  let firstCall = true;
   const callback = (...args) => {
     if (!HANDLERS[event]) {
-      logger.info(`webRequest.${event} called without listener being assigned`);
+      if (firstCall) {
+        firstCall = false;
+        logger.info(
+          `webRequest.${event} called without listener being assigned`,
+        );
+      }
       return;
     }
     return HANDLERS[event](...args);


### PR DESCRIPTION
Currently, there are many info warnings that are repetitive:
```
WTM [webrequest-pipeline]   log: webRequest.onCompleted called without listener being assigned webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onHeadersReceived called without listener being assigned 2 webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onCompleted called without listener being assigned 2 webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onHeadersReceived called without listener being assigned webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onCompleted called without listener being assigned webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onBeforeRequest called without listener being assigned webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onBeforeSendHeaders called without listener being assigned webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onHeadersReceived called without listener being assigned webrequest.js line 295 > importedModule:80:14
WTM [webrequest-pipeline]   log: webRequest.onCompleted called without listener being assigned
```