### PR TITLE
Naming consistency (request-reporter != url-reporter)

### DIFF
--- a/packages/reporting/src/request/steps/cookie-context.js
+++ b/packages/reporting/src/request/steps/cookie-context.js
@@ -32,12 +32,12 @@ export default class CookieContext {
 
     this.contextFromEvent = null;
     this.visitCache = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:cookie-context:visit-cache',
+      storageKey: 'wtm-request-reporting:cookie-context:visit-cache',
       ttlInMs: TIME_CLEANING_CACHE,
     });
 
     this.trustedThirdParties = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:cookie-context:trusted-third-parties',
+      storageKey: 'wtm-request-reporting:cookie-context:trusted-third-parties',
       ttlInMs: USED_TRUST_TIMEOUT,
     });
   }

--- a/packages/reporting/src/request/steps/oauth-detector.js
+++ b/packages/reporting/src/request/steps/oauth-detector.js
@@ -23,11 +23,11 @@ export default class OAuthDetector {
     Object.assign(this, DEFAULT_OPTIONS, options);
 
     this.clickActivity = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:oauth-detector:click-activity',
+      storageKey: 'wtm-request-reporting:oauth-detector:click-activity',
       ttlInMs: this.CLICK_TIMEOUT,
     });
     this.siteActivitiy = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:oauth-detector:site-activity',
+      storageKey: 'wtm-request-reporting:oauth-detector:site-activity',
       ttlInMs: this.VISIT_TIMEOUT,
     });
     this.subjectMainFrames = new Subject();

--- a/packages/reporting/src/request/steps/token-checker/token-domain.js
+++ b/packages/reporting/src/request/steps/token-checker/token-domain.js
@@ -22,7 +22,7 @@ export default class TokenDomain {
     this.db = db;
     this.blockedTokens = new Set();
     this.stagedTokenDomain = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:token-domain:staged-token-domain',
+      storageKey: 'wtm-request-reporting:token-domain:staged-token-domain',
       ttlInMs: STAGED_TOKEN_EXPIRY,
     });
   }

--- a/packages/reporting/src/request/steps/token-examiner.js
+++ b/packages/reporting/src/request/steps/token-examiner.js
@@ -29,7 +29,7 @@ export default class TokenExaminer {
     this.shouldCheckToken = shouldCheckToken;
     this.hashTokens = true;
     this.requestKeyValue = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:token-examiner:request-key-value',
+      storageKey: 'wtm-request-reporting:token-examiner:request-key-value',
     });
     this._syncTimer = null;
     this._lastPrune = null;

--- a/packages/reporting/src/request/steps/token-telemetry/cached-entry-pipeline.js
+++ b/packages/reporting/src/request/steps/token-telemetry/cached-entry-pipeline.js
@@ -24,7 +24,7 @@ export default class CachedEntryPipeline {
     this.db = db;
     this.trustedClock = trustedClock;
     this.cache = new ChromeStorageMap({
-      storageKey: `wtm-url-reporting:token-telemetry:${name}`,
+      storageKey: `wtm-request-reporting:token-telemetry:${name}`,
       ttlInMs: CACHE_TTL,
     });
     this.primaryKey = primaryKey;

--- a/packages/reporting/src/webrequest-pipeline/cname-uncloak.js
+++ b/packages/reporting/src/webrequest-pipeline/cname-uncloak.js
@@ -55,7 +55,7 @@ export default class CnameUnloak {
   constructor(dnsResolve, dnsTTL = 10 * 60 * 1000 /* 10 minutes */) {
     this.dnsResolve = dnsResolve;
     this.dnsCache = new ChromeStorageMap({
-      storageKey: 'wtm-url-reporting:webrequest-pipeline:dns-cache',
+      storageKey: 'wtm-request-reporting:webrequest-pipeline:dns-cache',
       ttlInMs: dnsTTL,
     });
     this.dnsPending = new Map();


### PR DESCRIPTION
With this change, it should be more intuitive to understand which component owns the keys.