### PR TITLE
By default, turn off fine-grained webrequest pipeline debug logs

### DIFF
--- a/packages/reporting/src/webrequest-pipeline/pipeline.js
+++ b/packages/reporting/src/webrequest-pipeline/pipeline.js
@@ -221,7 +221,7 @@ export default class Pipeline {
       // steps.
       if (cont === false) {
         if (this.isBreakable === true) {
-          logger.debug(this.name, webRequestContext.url, 'Break at', name);
+          // logger.debug(this.name, webRequestContext.url, 'Break at', name);
           break;
         }
         // we only reach here if the pipeline is not breakable: show a warning


### PR DESCRIPTION
IMHO, this debug log does not give much value to justify having it enabled by default. Since it triggers constantly, it makes it difficult to work with debug logs in the browser (without exporting logs to a file).