### PR TITLE
Limit assumption about browser APIs

### DIFF
--- a/packages/reporting/src/pages.js
+++ b/packages/reporting/src/pages.js
@@ -839,11 +839,17 @@ export default class Pages {
           this.chrome.webRequest[type]?.addListener &&
           this.chrome.webRequest[type]?.removeListener
         ) {
-          this.chrome.webRequest[type].addListener(
-            handler,
-            { urls: ['<all_urls>'] },
-            ['responseHeaders'],
-          );
+          try {
+            this.chrome.webRequest[type].addListener(
+              handler,
+              { urls: ['<all_urls>'] },
+              ['responseHeaders'],
+            );
+          } catch (e) {
+            this.chrome.webRequest[type].addListener(handler, {
+              urls: ['<all_urls>'],
+            });
+          }
           cleanup.push(() =>
             this.chrome.webRequest[type].removeListener(handler),
           );


### PR DESCRIPTION
If you add APIs to the list that do not support "responseHeaders", Chrome will ignore them, but Firefox will fail.

This is intended to keep the assumptions on the APIs as low as possible. Currently, all APIs that are used support "responseHeaders", so the change is not fixing a problem in production.