### PR TITLE
Fixed missing redirects

### DIFF
--- a/packages/reporting/src/page-quorum-check-handler.js
+++ b/packages/reporting/src/page-quorum-check-handler.js
@@ -14,14 +14,14 @@ import { BadJobError } from './errors';
 import random from './random';
 
 function createPageMessage(safePage, ctry) {
-  const { url, title, ref = null, red = null, search, lang } = safePage;
+  const { url, title, ref = null, redirects = null, search, lang } = safePage;
   const { activity } = safePage.aggregator;
 
   const payload = {
     url,
     t: title,
     ref,
-    red,
+    redirects,
     lang,
     ctry,
     activity,


### PR DESCRIPTION
Due to a typo, the redirects were not included. Also, renamed the field to be more descriptive.