### PR TITLE
Fixed: empty strings should also be treated as missing titles

### DIFF
--- a/packages/reporting/src/doublefetch-page-handler.js
+++ b/packages/reporting/src/doublefetch-page-handler.js
@@ -10,7 +10,7 @@
  */
 
 import logger from './logger';
-import { isNil, lazyInitAsync } from './utils';
+import { lazyInitAsync } from './utils';
 import { randomBetween } from './random';
 import { BadJobError } from './errors';
 import { anonymousHttpGet } from './http';
@@ -341,13 +341,13 @@ export default class DoublefetchPageHandler {
       return discard('noindex must be false (after)');
     }
 
-    if (isNil(page.title)) {
+    if (!page.title) {
       return discard('page title missing');
     }
-    if (isNil(before.title)) {
+    if (!before.title) {
       return discard('title missing (before)');
     }
-    if (isNil(after.title)) {
+    if (!after.title) {
       return discard('title missing (after)');
     }
 


### PR DESCRIPTION
Currently, it is also dropped but only after showing a warning:
https://github.com/whotracksme/webextension-packages/blob/c059da7db379ca94bef99bab9093e9b7dfce1161/packages/reporting/src/doublefetch-page-handler.js#L50