### PR TITLE
Performance tweaks and cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@cliqz/url-parser": "^1.1.5",
         "date-fns": "^2.29.3",
         "idb": "^7.1.1",
-        "linkedom": "^0.14.20",
-        "pako": "^2.0.4",
+        "linkedom": "^0.16.10",
+        "pako": "^2.1.0",
         "tldts-experimental": "^6.0.11"
       },
       "devDependencies": {
@@ -5043,7 +5043,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -5051,12 +5053,11 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -6122,13 +6123,14 @@
       "license": "MIT"
     },
     "node_modules/linkedom": {
-      "version": "0.14.26",
-      "license": "ISC",
+      "version": "0.16.10",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.10.tgz",
+      "integrity": "sha512-c316CX1FiPMU1v4+ExUzxr/gD5xqyCX2M3qtyL2nuoYQTsk0F5jRRwOFG7jRRxD3w7ONbLTLMrGBvq++Hmzzhg==",
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",
         "html-escaper": "^3.0.3",
-        "htmlparser2": "^8.0.1",
+        "htmlparser2": "^9.1.0",
         "uhyphen": "^0.2.0"
       }
     },
@@ -7319,8 +7321,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "2.0.4",
-      "license": "(MIT AND Zlib)"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10300,6 +10303,36 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "packages/reporting/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "packages/reporting/node_modules/linkedom": {
+      "version": "0.14.26",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.26.tgz",
+      "integrity": "sha512-mK6TrydfFA7phrnp+1j57ycBwFI5bGSW6YXlw9acHoqF+mP/y+FooEYYyniOt5Ot57FSKB3iwmnuQ1UUyNLm5A==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^8.0.1",
+        "uhyphen": "^0.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@cliqz/url-parser": "^1.1.5",
     "date-fns": "^2.29.3",
     "idb": "^7.1.1",
-    "linkedom": "^0.14.20",
-    "pako": "^2.0.4",
+    "linkedom": "^0.16.10",
+    "pako": "^2.1.0",
     "tldts-experimental": "^6.0.11"
   }
 }

--- a/packages/reporting/src/html-parser.js
+++ b/packages/reporting/src/html-parser.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { DOMParser } from 'linkedom';
+import { DOMParser } from 'linkedom/cached';
 
 export default function parseHtml(html) {
   const domParser = new DOMParser();

--- a/packages/reporting/src/page-structure.js
+++ b/packages/reporting/src/page-structure.js
@@ -13,28 +13,6 @@
 // It must not depend on no external functions (only the DOM API is safe to use).
 // Also, it should work on all supported browsers.
 export async function analyzePageStructure(doc) {
-  function countNodes(doc) {
-    let count = 0;
-    if (doc.body) {
-      const stack = [doc.body];
-
-      while (stack.length > 0) {
-        const curr = stack.pop();
-        count++;
-
-        let child = curr.firstElementChild;
-        while (child) {
-          stack.push(child);
-          if (child.shadowRoot) {
-            stack.push(child.shadowRoot);
-          }
-          child = child.nextElementSibling;
-        }
-      }
-    }
-    return count;
-  }
-
   function getTitle(doc) {
     if (doc.title) {
       return doc.title;
@@ -115,14 +93,6 @@ export async function analyzePageStructure(doc) {
     return og;
   }
 
-  function detectCsrfToken(doc) {
-    const elem = doc.querySelector('html > head > meta[name="csrf-token"]');
-    if (elem && elem.getAttribute('content')) {
-      return true;
-    }
-    return false;
-  }
-
   doc = doc || document;
 
   try {
@@ -144,15 +114,6 @@ export async function analyzePageStructure(doc) {
     const language = parseHtmlLangAttribute(doc);
     const og = parseOpenGraphMetaTags(doc);
 
-    const numNodes = countNodes(doc);
-    const numLinks = doc.querySelectorAll('a').length;
-    const numInputs = doc.querySelectorAll('input').length;
-    const numHiddenInputs = doc.querySelectorAll('input[type="hidden"]').length;
-    const numPasswordFields = doc.querySelectorAll(
-      'input[type="password"]',
-    ).length;
-    const hasCsrfToken = detectCsrfToken(doc);
-
     return {
       title,
       url,
@@ -161,14 +122,6 @@ export async function analyzePageStructure(doc) {
         language,
         contentType,
         og,
-      },
-      content: {
-        numNodes,
-        numLinks,
-        numInputs,
-        numHiddenInputs,
-        numPasswordFields,
-        hasCsrfToken,
       },
       noindex: false,
       requestedIndex,

--- a/packages/reporting/test/helpers/dom-parsers.js
+++ b/packages/reporting/test/helpers/dom-parsers.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import * as linkedom from 'linkedom';
+import * as linkedom from 'linkedom/cached';
 
 /**
  * Different implementations of the DOM API.


### PR DESCRIPTION
* Removes unused code in the page structure analyzer
* Enables caching in linkedom, which is slightly faster

Note on Linkedom caching: caching increases the memory footprint, but I do not expect it to be a problem. It is not easy to measure, but the runtime was about 1/3 faster in tests. Our use cases should benefit from caching, since there are never DOM manipulation after the HTML is parsed. 