### PR TITLE
Update to latest linkedom (fixes empty document.title)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@cliqz/url-parser": "^1.1.5",
         "date-fns": "^2.29.3",
         "idb": "^7.1.1",
-        "linkedom": "^0.16.10",
+        "linkedom": "^0.16.11",
         "pako": "^2.1.0",
         "tldts-experimental": "^6.0.11"
       },
@@ -6123,9 +6123,9 @@
       "license": "MIT"
     },
     "node_modules/linkedom": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.10.tgz",
-      "integrity": "sha512-c316CX1FiPMU1v4+ExUzxr/gD5xqyCX2M3qtyL2nuoYQTsk0F5jRRwOFG7jRRxD3w7ONbLTLMrGBvq++Hmzzhg==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.11.tgz",
+      "integrity": "sha512-WgaTVbj7itjyXTsCvgerpneERXShcnNJF5VIV+/4SLtyRLN+HppPre/WDHRofAr2IpEuujSNgJbCBd5lMl6lRw==",
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@cliqz/url-parser": "^1.1.5",
     "date-fns": "^2.29.3",
     "idb": "^7.1.1",
-    "linkedom": "^0.16.10",
+    "linkedom": "^0.16.11",
     "pako": "^2.1.0",
     "tldts-experimental": "^6.0.11"
   }


### PR DESCRIPTION
Update to latest linkedom, which fixes a regression after enabling caching

refs https://github.com/WebReflection/linkedom/pull/266
refs https://github.com/ghostery/ghostery-extension/pull/1511