### PR TITLE
Fixed: do not depend on Array.toString for sorting Object.entries

### DIFF
--- a/packages/reporting/src/utils.js
+++ b/packages/reporting/src/utils.js
@@ -184,6 +184,14 @@ export function flattenObject(obj, parentPath = []) {
   }, []);
 }
 
+function sortedObjectEntries(x) {
+  return Object.entries(x).sort((a, b) => {
+    if (a[0] < b[0]) return -1;
+    if (a[0] > b[0]) return 1;
+    return 0;
+  });
+}
+
 /**
  * This is not a full deepEqual implementation. But it should be
  * able to detect common data objects with primitive types.
@@ -230,7 +238,7 @@ export function equalityCanBeProven(x, y) {
     }
     return (
       y.constructor === Object &&
-      equalityCanBeProven(Object.entries(x).sort(), Object.entries(y).sort())
+      equalityCanBeProven(sortedObjectEntries(x), sortedObjectEntries(y))
     );
   }
 

--- a/packages/reporting/test/utils.spec.js
+++ b/packages/reporting/test/utils.spec.js
@@ -133,6 +133,24 @@ describe('#equalityCanBeProven', function () {
       }),
     );
   });
+
+  describe('should handle edge cases found by property based testing', function () {
+    it('should not throw if "toString" is set to undefined', function () {
+      expect(
+        equalityCanBeProven(
+          {},
+          {
+            '': {},
+            ' ': [
+              {
+                'toString': undefined,
+              },
+            ],
+          },
+        ),
+      ).to.eql(false);
+    });
+  });
 });
 
 describe('#lazyInitAsync', function () {


### PR DESCRIPTION
Fixes a test that can rarely fail. For specific inputs "equalityCanBeProven" would have failed with an exception:

```
 FAILED TESTS:
  #equalityCanBeProven
    ✖ proving equality implies deepEqual
      Chrome Headless 123.0.6312.105 (Linux x86_64)
    Property failed after 38 tests
    { seed: -1867831413, path: "37:0:4:2:2:3:4:3:5:5:81:81", endOnFailure: true }
    Counterexample: [{},{"":{}," ":[{"toString":undefined}]}]
    Shrunk 11 time(s)
    Got error: TypeError: Cannot convert object to primitive value
    
    Stack trace: TypeError: Cannot convert object to primitive value
        at Array.join (<anonymous>)
        at Array.toString (<anonymous>)
        at Array.join (<anonymous>)
        at Array.toString (<anonymous>)
        at Array.sort (<anonymous>)
        at equalityCanBeProven (src/utils.js:233:71 <- test/index.js:48499:72)
        at test/utils.spec.js:129:13 <- test/index.js:89226:14
        at Property.predicate (node_modules/fast-check/lib/esm/check/property/Property.js:14:54 <- test/index.js:73161:55)
        at Property.run (node_modules/fast-check/lib/esm/check/property/Property.generic.js:38:33 <- test/index.js:73120:34)
        at runIt (node_modules/fast-check/lib/esm/check/runner/Runner.js:14:30 <- test/index.js:76695:31)
```