### PR TITLE
Upgrade linkedom in all places

### DIFF
--- a/packages/reporting/package.json
+++ b/packages/reporting/package.json
@@ -38,7 +38,7 @@
     "@cliqz/url-parser": "^1.1.5",
     "date-fns": "^2.29.3",
     "idb": "^7.1.1",
-    "linkedom": "^0.14.20",
+    "linkedom": "^0.16.11",
     "tldts-experimental": "^6.0.11"
   },
   "exports": {


### PR DESCRIPTION
reporting still had a local overwrite of linkedom with an old version. This created problems when using npm link