### PR TITLE
Improve the heuristic that compares URLs before and after double-fetch

### DIFF
--- a/packages/reporting/src/url-cleaner.js
+++ b/packages/reporting/src/url-cleaner.js
@@ -45,3 +45,16 @@ export function removeQueryParams(url, queryParams) {
     return `${beforeSearch}?${parts.join('&')}${hash}`;
   }
 }
+
+/**
+ * Given a URL, it returns an equivalent URL, but with the hash removed.
+ * If the URL did not have a hash, the unmodifed URL will be returned.
+ *
+ * Note: this function will not do any decoding. Instead, it will try
+ * to preserve the original URL as best as it can (e.g. the invalid URL
+ * "https://example.test?q=x y" will not be normalized to the valid URL
+ * "https://example.test/?q=x%20y").
+ */
+export function removeSearchHash(url) {
+  return split0(url, '#');
+}

--- a/packages/reporting/test/url-cleaner.spec.js
+++ b/packages/reporting/test/url-cleaner.spec.js
@@ -11,7 +11,7 @@
 
 import { expect } from 'chai';
 
-import { removeQueryParams } from '../src/url-cleaner.js';
+import { removeQueryParams, removeSearchHash } from '../src/url-cleaner.js';
 
 /**
  * Note: this function is also used to implement the "removeParams" builtin.
@@ -57,5 +57,46 @@ describe('#removeQueryParams', function () {
         );
       });
     });
+  });
+});
+
+describe('#removeSearchHash', function () {
+  it('should work in the happy path', function () {
+    expect(removeSearchHash('https://example.test/foo#')).to.eql(
+      'https://example.test/foo',
+    );
+    expect(removeSearchHash('https://example.test/foo#remove-me')).to.eql(
+      'https://example.test/foo',
+    );
+    expect(removeSearchHash('https://example.test/foo?x=y#')).to.eql(
+      'https://example.test/foo?x=y',
+    );
+    expect(removeSearchHash('https://example.test/foo?x=y#remove-me')).to.eql(
+      'https://example.test/foo?x=y',
+    );
+  });
+
+  it('should not change URLs without hashes', function () {
+    expect(removeSearchHash('https://example.test/foo')).to.eql(
+      'https://example.test/foo',
+    );
+    expect(removeSearchHash('https://example.test/foo?x=y')).to.eql(
+      'https://example.test/foo?x=y',
+    );
+  });
+
+  it('should work with multiple hashes', function () {
+    expect(removeSearchHash('https://example.test/foo#remove#me')).to.eql(
+      'https://example.test/foo',
+    );
+    expect(removeSearchHash('https://example.test/foo##remove#me')).to.eql(
+      'https://example.test/foo',
+    );
+    expect(removeSearchHash('https://example.test/foo##')).to.eql(
+      'https://example.test/foo',
+    );
+    expect(removeSearchHash('https://example.test/foo#remove#me#')).to.eql(
+      'https://example.test/foo',
+    );
   });
 });


### PR DESCRIPTION
Since the URL hash gets removed in a previous normalization step, we can ignore it when comparing URLs. But only if there are strong indicators that we are not dealing with a single page application.