### PR TITLE
Do not use sub-millisecond resolution for times

### DIFF
--- a/packages/reporting/src/request/page-telemetry.js
+++ b/packages/reporting/src/request/page-telemetry.js
@@ -26,7 +26,7 @@ export default function buildPageLoadObject(page) {
     path: truncatedHash(truncatePath(urlParts.path)),
     scheme: urlParts.scheme,
     c: 1,
-    t: page.destroyed - page.created,
+    t: Math.round(page.destroyed - page.created),
     active: page.activeTime,
     counter: page.counter,
     ra: 0,


### PR DESCRIPTION
`page.created` is not initialized from `Date.now()`, but contains a higher resolution. In the old messages, it was an integer value, now it is a float. Arguably, we should apply some noise to it; but for now, round at least to guarantee integer values.