### PR TITLE
Clean up the handling of "ver" among messages.

### DIFF
--- a/packages/reporting/src/alive-check.js
+++ b/packages/reporting/src/alive-check.js
@@ -11,6 +11,7 @@
 
 import logger from './logger';
 import { requireString, requireParam } from './utils';
+import random from './random';
 
 const HOUR = 1000 * 60 * 60;
 
@@ -125,6 +126,8 @@ export default class AliveCheck {
     const message = {
       action: 'wtm.alive',
       payload,
+      ver: 3, // Note: no need to keep this number in sync among messages
+      'anti-duplicates': Math.floor(random() * 10000000),
     };
 
     // Note that it is intentional here to bypass the job scheduler.

--- a/packages/reporting/src/page-quorum-check-handler.js
+++ b/packages/reporting/src/page-quorum-check-handler.js
@@ -41,7 +41,7 @@ function createPageMessage(safePage, ctry) {
   const body = {
     action: 'wtm.page',
     payload,
-    ver: '2.9', // TODO: eliminate code duplication (especially, the magic constant '2.9')
+    ver: 3, // Note: no need to keep this number in sync among messages
     'anti-duplicates': Math.floor(random() * 10000000),
   };
   return { body, deduplicateBy };

--- a/packages/reporting/src/search-extractor.js
+++ b/packages/reporting/src/search-extractor.js
@@ -327,7 +327,7 @@ export default class SearchExtractor {
       const body = {
         action,
         payload,
-        ver: '2.9', // TODO: eliminate code duplication (especially, the magic constant '2.9')
+        ver: 3, // Note: no need to keep this number in sync among messages
         'anti-duplicates': Math.floor(random() * 10000000),
       };
       messages.push({ body, deduplicateBy });

--- a/packages/reporting/test/duplicate-detector.spec.js
+++ b/packages/reporting/test/duplicate-detector.spec.js
@@ -32,7 +32,7 @@ function mkMessage({ action = 'test-action', payload, deduplicateBy } = {}) {
     type: 'test-type',
     action,
     payload,
-    ver: '2.9',
+    ver: 3,
     'anti-duplicates': 1,
   };
   return { body, deduplicateBy };


### PR DESCRIPTION
It is not a requirement of keep them in sync among the code base. In fact, it is better to see them as a minimum version and to increase only messages that are affected. Increases the ver will split the population. That can be intentional to get rid of old clients - like in this commit - but it should be done only if needed.

Also, changed the type from string to numbers to simplify the processing on the server in the future.