### PR TITLE
Support expansion for plain objects in deduplicator expressions

### DIFF
--- a/reporting/src/duplicate-detector.js
+++ b/reporting/src/duplicate-detector.js
@@ -65,6 +65,18 @@ function extractPath(obj, path, pos = 0) {
       if (results.length > 0) {
         return { match: true, value: results };
       }
+    } else if (obj && typeof obj === 'object') {
+      // handle plain objects
+      const results = {};
+      for (const [key, val] of Object.entries(obj)) {
+        const { match, value } = extractPath(val, path, pos + 1);
+        if (match) {
+          results[key] = value;
+        }
+      }
+      if (Object.keys(results).length > 0) {
+        return { match: true, value: results };
+      }
     }
     return { match: false };
   }

--- a/reporting/test/duplicate-detector.spec.js
+++ b/reporting/test/duplicate-detector.spec.js
@@ -413,6 +413,169 @@ describe('#computeDeduplicationKey', function () {
     );
   });
 
+  it('should handle the expansion of array-like objects', function () {
+    duplicatedPayload(
+      {
+        0: {
+          x: 'foo',
+        },
+        1: {
+          x: 'bar',
+        },
+      },
+      {
+        0: {
+          x: 'foo',
+        },
+        1: {
+          x: 'bar',
+        },
+      },
+      '[].x',
+    );
+
+    nonDuplicatedPayload(
+      {
+        0: {
+          x: 'foo',
+        },
+        1: {
+          x: 'bar',
+        },
+      },
+      {
+        0: {
+          x: 'foo',
+        },
+        1: {
+          x: 'not bar',
+        },
+      },
+      '[].x',
+    );
+
+    duplicatedPayload(
+      {
+        0: {
+          x: 'foo',
+        },
+        1: {
+          x: 'bar',
+        },
+      },
+      {
+        0: {
+          x: 'foo',
+        },
+        1: {
+          x: 'bar',
+          ignore: 'not part of key',
+        },
+      },
+      '[].x',
+    );
+
+    duplicatedPayload(
+      {
+        x: {
+          foo: 'foo',
+          bar: 'bar',
+        },
+        y: {
+          foo: 'foo',
+          bar: 'bar',
+        },
+      },
+      {
+        y: {
+          bar: 'bar',
+          foo: 'foo',
+        },
+        x: {
+          bar: 'bar',
+          foo: 'foo',
+        },
+      },
+      '[].foo,[].bar',
+    );
+  });
+
+  it('should handle the expansion of plain objects', function () {
+    duplicatedPayload(
+      {
+        foo: 'foo',
+        bar: 'bar',
+      },
+      {
+        bar: 'bar',
+        foo: 'foo',
+      },
+      '[]',
+    );
+
+    duplicatedPayload(
+      {
+        foo: {
+          x: 'foo',
+        },
+        bar: {
+          x: 'bar',
+        },
+      },
+      {
+        bar: {
+          x: 'bar',
+        },
+        foo: {
+          x: 'foo',
+        },
+      },
+      '[].x',
+    );
+
+    nonDuplicatedPayload(
+      {
+        foo: {
+          x: 'foo',
+          y: 'only in first elem',
+        },
+        bar: {
+          x: 'bar',
+        },
+      },
+      {
+        bar: {
+          x: 'bar',
+        },
+        foo: {
+          x: 'foo',
+        },
+      },
+      '[].x,[].y',
+    );
+
+    duplicatedPayload(
+      {
+        foo: {
+          x: 'foo',
+          y: 'only in first elem, but will be ignored',
+        },
+        bar: {
+          x: 'bar',
+        },
+      },
+      {
+        bar: {
+          x: 'bar',
+        },
+        foo: {
+          x: 'foo',
+        },
+      },
+      '[].x',
+    );
+  });
+
   it('should ignore the order of fields (non-nested)', function () {
     duplicatedPayload(
       {


### PR DESCRIPTION
The ".[]" expansion in deduplicator expressions should also work on plain objects, not just arrays.