### PR TITLE
Improve 'json' primitive

### DIFF
--- a/reporting/src/patterns.js
+++ b/reporting/src/patterns.js
@@ -288,6 +288,9 @@ const TRANSFORMS = new Map(
       try {
         let obj = JSON.parse(text);
         for (const field of path.split('.')) {
+          if (!Object.hasOwn(obj, field)) {
+            return '';
+          }
           obj = obj[field];
         }
         if (typeof obj === 'string') {


### PR DESCRIPTION
When parsing JSON, we should no attempt to extract implicitly properties like 'toString'. This guarantees that the function will always return a result of type 'string'.

This should also fix rare test failures in the QuickCheck tests.