### PR TITLE
Preserve "openedFrom" information during redirects opening in new tabs

### DIFF
--- a/reporting/karma.conf.cjs
+++ b/reporting/karma.conf.cjs
@@ -17,6 +17,8 @@ module.exports = function (config) {
     client: {
       TEST_FIXTURES_URL: process.env.TEST_FIXTURES_URL, // for test/search-extractor.spec.js
       REPLAY_FIXTURES_URL: process.env.REPLAY_FIXTURES_URL, // for test/pages.spec.js
+      VERBOSE_REPLAY: process.env.VERBOSE_REPLAY, // for test/pages.spec.js (better debugging)
+      ENABLE_SELF_CHECKS: process.env.ENABLE_SELF_CHECKS, // for test/pages.spec.js (might catch different bugs)
     },
   });
 };


### PR DESCRIPTION
If a link opens in a new tab, some information could get lost.

Also, improved the output of the tests. Not enabled by default, but only when the VERBOSE_REPLAY environment is set.

Additionally, ENABLE_SELF_CHECKS runs self check at each step. It is also an opt-in, because it comes with a performance cost and also may change the results.