### PR TITLE
PageStore fixes

### DIFF
--- a/reporting/src/request/index.js
+++ b/reporting/src/request/index.js
@@ -524,7 +524,8 @@ export default class RequestMonitor {
               // check for tracking status headers for first party
               const trackingStatus = getTrackingStatus(state);
               if (trackingStatus) {
-                state.page.setTrackingStatus(trackingStatus);
+                state.page.tsv = trackingStatus.value;
+                state.page.tsvId = trackingStatus.statusId;
               }
               return false;
             }

--- a/reporting/src/request/steps/page-logger.js
+++ b/reporting/src/request/steps/page-logger.js
@@ -11,6 +11,7 @@
 
 /* eslint no-param-reassign: 'off' */
 import { truncateDomain } from '../utils';
+import { getStatsForDomain } from '../../webrequest-pipeline/page.js';
 
 // maps string (web-ext) to int (FF cpt). Anti-tracking still uses these legacy types.
 const TYPE_LOOKUP = {
@@ -44,7 +45,8 @@ export default class PageLogger {
   }
 
   _attachCounters(state) {
-    const stats = state.page.getStatsForDomain(
+    const stats = getStatsForDomain(
+      state.page,
       truncateDomain(state.urlParts.domainInfo, 2),
     );
     state.reqLog = stats;

--- a/reporting/src/request/utils/chrome-storage-map.js
+++ b/reporting/src/request/utils/chrome-storage-map.js
@@ -112,7 +112,7 @@ export default class ChromeStorageMap {
   values() {
     this._warnIfOutOfSync();
     this._expireOldEntries();
-    return Object.values(this._inMemoryMap);
+    return this._inMemoryMap.values();
   }
 
   has(_key) {

--- a/reporting/src/webrequest-pipeline/page.js
+++ b/reporting/src/webrequest-pipeline/page.js
@@ -16,125 +16,102 @@ export const PAGE_LOADING_STATE = {
   COMPLETE: 'complete',
 };
 
-export default class Page {
-  constructor({ id, active, url, incognito, created }) {
-    this.id = id || 0;
-    this.url = url;
-    this.isRedirect = false;
-    this.isPrivate = incognito;
-    this.isPrivateServer = false;
-    this.created = created || Date.now();
-    this.destroyed = null;
-    this.lastRequestId = null;
-    this.frames = {
-      0: {
-        parentFrameId: -1,
-        url,
-      },
-    };
-    this.state = PAGE_LOADING_STATE.CREATED;
+export function create({ id, active, url, incognito, created }) {
+  const page = {};
+  page.id = id || 0;
+  page.url = url;
+  page.isRedirect = false;
+  page.isPrivate = incognito;
+  page.isPrivateServer = false;
+  page.created = created || Date.now();
+  page.destroyed = null;
+  page.lastRequestId = null;
+  page.frames = {
+    0: {
+      parentFrameId: -1,
+      url,
+    },
+  };
+  page.state = PAGE_LOADING_STATE.CREATED;
 
-    this.activeTime = 0;
-    this.activeFrom = active ? Date.now() : 0;
+  page.activeTime = 0;
+  page.activeFrom = active ? Date.now() : 0;
 
-    this.requestStats = {};
-    this.annotations = {};
-    this.counter = 0;
+  page.requestStats = {};
+  page.annotations = {};
+  page.counter = 0;
 
-    this.tsv = '';
-    this.tsvId = undefined;
+  page.tsv = '';
+  page.tsvId = undefined;
+  return page;
+}
+
+export function setActive(page, active) {
+  if (active && page.activeFrom === 0) {
+    page.activeFrom = Date.now();
+  } else if (!active && page.activeFrom > 0) {
+    page.activeTime += Date.now() - page.activeFrom;
+    page.activeFrom = 0;
   }
+}
 
-  setActive(active) {
-    if (active && this.activeFrom === 0) {
-      this.activeFrom = Date.now();
-    } else if (!active && this.activeFrom > 0) {
-      this.activeTime += Date.now() - this.activeFrom;
-      this.activeFrom = 0;
-    }
+export function getStatsForDomain(page, domain) {
+  let stats = page.requestStats[domain];
+  if (!stats) {
+    stats = {};
+    page.requestStats[domain] = stats;
   }
+  return stats;
+}
 
-  updateState(newState) {
-    this.state = newState;
-  }
+export function getFrameAncestors(page, { parentFrameId }) {
+  const ancestors = [];
 
-  stage() {
-    this.setActive(false);
-    this.destroyed = Date.now();
-    // unset previous (to prevent history chain memory leak)
-    this.previous = undefined;
-  }
+  // Reconstruct frame ancestors
+  let currentFrameId = parentFrameId;
+  while (currentFrameId !== -1) {
+    const frame = page.frames[currentFrameId];
 
-  getStatsForDomain(domain) {
-    let stats = this.requestStats[domain];
-    if (!stats) {
-      stats = {};
-      this.requestStats[domain] = stats;
-    }
-    return stats;
-  }
-
-  setTrackingStatus(status) {
-    this.tsv = status.value;
-    this.tsvId = status.statusId;
-  }
-
-  getFrameAncestors({ parentFrameId }) {
-    const ancestors = [];
-
-    // Reconstruct frame ancestors
-    let currentFrameId = parentFrameId;
-    while (currentFrameId !== -1) {
-      const frame = this.frames[currentFrameId];
-
-      // If `frame` if undefined, this means we do not have any information
-      // about the frame associated with `currentFrameId`. This can happen if
-      // the event for `main_frame` or `sub_frame` was not emitted from the
-      // webRequest API for this frame; this can happen when Service Workers
-      // are used. In this case, we consider that the parent frame is the main
-      // frame (which is very likely the case).
-      if (frame === undefined) {
-        ancestors.push({
-          frameId: 0,
-          url: this.url,
-        });
-        break;
-      }
-
-      // Continue going up the ancestors chain
-      ancestors.push({
-        frameId: currentFrameId,
-        url: frame.url,
-      });
-      currentFrameId = frame.parentFrameId;
-    }
-
-    return ancestors;
-  }
-
-  /**
-   * Return the URL of top-level document (i.e.: tab URL).
-   */
-  getTabUrl() {
-    return this.url;
-  }
-
-  /**
-   * Return the URL of the frame.
-   */
-  getFrameUrl(context) {
-    const { frameId } = context;
-
-    const frame = this.frames[frameId];
-
-    // In some cases, frame creation does not trigger a webRequest event (e.g.:
-    // if the iframe is specified in the HTML of the page directly). In this
-    // case we try to fall-back to something else: documentUrl, originUrl,
-    // initiator.
+    // If `frame` if undefined, this means we do not have any information
+    // about the frame associated with `currentFrameId`. This can happen if
+    // the event for `main_frame` or `sub_frame` was not emitted from the
+    // webRequest API for this frame; this can happen when Service Workers
+    // are used. In this case, we consider that the parent frame is the main
+    // frame (which is very likely the case).
     if (frame === undefined) {
-      return context.documentUrl || context.originUrl || context.initiator;
+      ancestors.push({
+        frameId: 0,
+        url: page.url,
+      });
+      break;
     }
 
-    return frame.url;
+    // Continue going up the ancestors chain
+    ancestors.push({
+      frameId: currentFrameId,
+      url: frame.url,
+    });
+    currentFrameId = frame.parentFrameId;
   }
+
+  return ancestors;
+}
+
+/**
+ * Return the URL of the frame.
+ */
+export function getFrameUrl(page, context) {
+  const { frameId } = context;
+
+  const frame = page.frames[frameId];
+
+  // In some cases, frame creation does not trigger a webRequest event (e.g.:
+  // if the iframe is specified in the HTML of the page directly). In this
+  // case we try to fall-back to something else: documentUrl, originUrl,
+  // initiator.
+  if (frame === undefined) {
+    return context.documentUrl || context.originUrl || context.initiator;
+  }
+
+  return frame.url;
 }

--- a/reporting/src/webrequest-pipeline/webrequest-context.js
+++ b/reporting/src/webrequest-pipeline/webrequest-context.js
@@ -11,6 +11,7 @@
 
 import { parse } from '../utils/url.js';
 import logger from './logger.js';
+import { getFrameUrl, getFrameAncestors } from './page.js';
 
 /**
  * Transform an array of headers (i.e.: `{ name, value }`) into a `Map`.
@@ -61,13 +62,13 @@ export default class WebRequestContext {
     // **Chromium addition**
     // frameAncestors
     if (context.frameAncestors === undefined) {
-      context.frameAncestors = page ? page.getFrameAncestors(context) : [];
+      context.frameAncestors = page ? getFrameAncestors(page, context) : [];
     }
 
     // Cliqz-specific extensions to webRequest details
     context.page = page;
-    context.tabUrl = context.tabUrl || (page && page.getTabUrl());
-    context.frameUrl = context.frameUrl || (page && page.getFrameUrl(context));
+    context.tabUrl = context.tabUrl || (page && page.url);
+    context.frameUrl = context.frameUrl || (page && getFrameUrl(page, context));
     context.isPrivate = page ? page.isPrivate : null;
     context.isMainFrame = context.type === 'main_frame';
     context.isRedirect = page && context.isMainFrame && page.isRedirect;

--- a/reporting/test/webrequest-pipeline/page-store.test.js
+++ b/reporting/test/webrequest-pipeline/page-store.test.js
@@ -104,7 +104,7 @@ describe('PageStore', function () {
       chrome.webNavigation.onBeforeNavigate.dispatch(details);
       expect(listener).to.not.have.been.called;
       const page = store.tabs.get(details.tabId);
-      page.updateState(PAGE_LOADING_STATE.COMPLETE);
+      page.state = PAGE_LOADING_STATE.COMPLETE;
       chrome.webNavigation.onBeforeNavigate.dispatch({
         ...details,
         timeStamp: details.timeStamp + 300,
@@ -124,7 +124,7 @@ describe('PageStore', function () {
       };
       chrome.webNavigation.onBeforeNavigate.dispatch(details);
       expect(listener).to.not.have.been.called;
-      store.tabs.get(details.tabId).updateState(PAGE_LOADING_STATE.COMPLETE);
+      store.tabs.get(details.tabId).state = PAGE_LOADING_STATE.COMPLETE;
       chrome.webNavigation.onBeforeNavigate.dispatch({
         ...details,
         timeStamp: details.timeStamp + 1,


### PR DESCRIPTION
`chrome.storage` is incapable to persisting instances of JavaScipt Classes, so Page objects could not be retrieved from it. This PR changes Page representation to plain object. 
