### PR TITLE
Request: keys pipeline picks a random tokens if too many

### DIFF
--- a/reporting/src/request/steps/token-telemetry/index.js
+++ b/reporting/src/request/steps/token-telemetry/index.js
@@ -21,6 +21,7 @@ const DEFAULT_CONFIG = {
   // key batches, max 450 messages/hour
   KEY_BATCH_INTERVAL: 80 * 1000,
   KEY_BATCH_SIZE: 10,
+  KEY_TOKENS_LIMIT: 100,
   // clean every 4 mins (activity triggered)
   CLEAN_INTERVAL: 4 * 60 * 1000,
   // batch size of incoming tokens

--- a/reporting/src/request/steps/token-telemetry/index.js
+++ b/reporting/src/request/steps/token-telemetry/index.js
@@ -21,7 +21,7 @@ const DEFAULT_CONFIG = {
   // key batches, max 450 messages/hour
   KEY_BATCH_INTERVAL: 80 * 1000,
   KEY_BATCH_SIZE: 10,
-  KEY_TOKENS_LIMIT: 100,
+  KEY_TOKENS_LIMIT: 512,
   // clean every 4 mins (activity triggered)
   CLEAN_INTERVAL: 4 * 60 * 1000,
   // batch size of incoming tokens


### PR DESCRIPTION
Keys telemetry could accumulate too many tokens that cannot be pushed via the anonymous communication due to its size restrictions. Such case was noticed at soundcloud.com, see for details of such message https://github.com/ghostery/broken-page-reports/issues/873#issuecomment-2450496021

With the sample of tokens being sent, there is an expectation for the `QSWhitelist` to catch up and fix the soundcloud.com breakage.