### PR TITLE
Fixed errors when request reporter is not ready yet

### DIFF
--- a/reporting/src/request/index.js
+++ b/reporting/src/request/index.js
@@ -307,7 +307,10 @@ export default class RequestReporter {
   }
 
   onBeforeRequest = (details) => {
-    if (!this.ready) return;
+    if (!this.ready) {
+      logger.warn('onBeforeRequest skipped (not ready)');
+      return;
+    }
     const state = WebRequestContext.fromDetails(details, this.pageStore);
     const response = new BlockingResponse(details, 'onBeforeRequest');
     // checkState
@@ -390,7 +393,10 @@ export default class RequestReporter {
   };
 
   onBeforeSendHeaders = (details) => {
-    if (!this.ready) return;
+    if (!this.ready) {
+      logger.warn('onBeforeSendHeaders skipped (not ready)');
+      return;
+    }
     const state = WebRequestContext.fromDetails(details, this.pageStore);
     const response = new BlockingResponse(details, 'onBeforeSendHeaders');
     // checkState
@@ -476,7 +482,10 @@ export default class RequestReporter {
   };
 
   onHeadersReceived = (details) => {
-    if (!this.ready) return;
+    if (!this.ready) {
+      logger.warn('onHeadersReceived skipped (not ready)');
+      return;
+    }
     const state = WebRequestContext.fromDetails(details, this.pageStore);
     const response = new BlockingResponse(details, 'onHeadersReceived');
     // checkState
@@ -540,7 +549,10 @@ export default class RequestReporter {
   };
 
   onCompleted = (details) => {
-    if (!this.ready) return;
+    if (!this.ready) {
+      logger.warn('onCompleted skipped (not ready)');
+      return;
+    }
     this.whitelistedRequestCache.delete(details.requestId);
     const state = WebRequestContext.fromDetails(details, this.pageStore);
     // checkState
@@ -556,7 +568,10 @@ export default class RequestReporter {
   };
 
   onErrorOccurred = (details) => {
-    if (!this.ready) return;
+    if (!this.ready) {
+      logger.warn('onErrorOccurred skipped (not ready)');
+      return;
+    }
     this.whitelistedRequestCache.delete(details.requestId);
   };
 
@@ -706,6 +721,10 @@ export default class RequestReporter {
   }
 
   recordClick(event, context, href, sender) {
+    if (!this.ready) {
+      logger.warn('recordClick skipped (not ready)');
+      return;
+    }
     this.cookieContext.setContextFromEvent(event, context, href, sender);
     this.oAuthDetector.recordClick(sender);
   }


### PR DESCRIPTION
- fixed: recordClick: this.cookieContext only available if ready
- logging if events or requests get dropped if not ready