### PR TITLE
Run compatibility checks before placeholder replacements in onBeforeRequest

### DIFF
--- a/reporting/src/request/index.js
+++ b/reporting/src/request/index.js
@@ -379,6 +379,9 @@ export default class RequestReporter {
     if (this.isQSEnabled() === false) {
       return response.toWebRequestResponse();
     }
+    if (this.checkCompatibilityList(state) === false) {
+      return response.toWebRequestResponse();
+    }
 
     this.#reportTrackerInteraction('fingerprint-removed', state);
 


### PR DESCRIPTION
Compatibility checks should also have an effect on placeholder replacements in onBeforeRequest, and not be limited to onBeforeSendHeaders; otherwise, exceptions in https://cdn.ghostery.com/antitracking/config.json are ignored.

From my understanding, the compatibility lists so far have only an effect on HTTP headers, but not on HTTP url parameters.

 (Note: placeholder replacement means replacing a potential tracking parameter by the fixed string "ghostery").