### PR TITLE
Fix anti-tracking on Android

### DIFF
--- a/reporting/src/request/page-store.js
+++ b/reporting/src/request/page-store.js
@@ -77,7 +77,9 @@ export default class PageStore {
     chrome.webNavigation.onBeforeNavigate.addListener(this.#onBeforeNavigate);
     chrome.webNavigation.onCommitted.addListener(this.#onNavigationCommitted);
     chrome.webNavigation.onCompleted.addListener(this.#onNavigationCompleted);
-    chrome.windows.onFocusChanged?.addListener(this.#onWindowFocusChanged);
+
+    // Note: not available on Firefox Android
+    chrome.windows?.onFocusChanged?.addListener(this.#onWindowFocusChanged);
 
     // popupate initially open tabs
     (await chrome.tabs.query({})).forEach((tab) => this.#onTabCreated(tab));
@@ -103,7 +105,7 @@ export default class PageStore {
     chrome.webNavigation.onCompleted.removeListener(
       this.#onNavigationCompleted,
     );
-    chrome.windows.onFocusChanged?.removeListener(this.#onWindowFocusChanged);
+    chrome.windows?.onFocusChanged?.removeListener(this.#onWindowFocusChanged);
   }
 
   checkIfEmpty() {
@@ -182,6 +184,7 @@ export default class PageStore {
     }
   };
 
+  // Note: not available on Firefox Android
   #onWindowFocusChanged = async (focusedWindowId) => {
     const activeTabs = await chrome.tabs.query({ active: true });
     for (const { id, windowId } of activeTabs) {


### PR DESCRIPTION
Handle the lack of chrome.windows gracefully. Currently, anti-tracking crashes on startup on Android.