### PR TITLE
Randomly delay sending of request reporter messages 

### DIFF
--- a/reporting/example/index.js
+++ b/reporting/example/index.js
@@ -47,7 +47,11 @@ function createStorage() {
 
 const communication = {
   send(msg) {
-    console.warn('[Communication]', msg);
+    console.log(
+      '%c[DRY-RUN] send message:',
+      'color: blue; font-size: 30px;',
+      msg,
+    );
   },
   // TODO: use actuall anonymous-communication to access quorum
   sendInstant(msg) {
@@ -90,7 +94,13 @@ const urlReporter = new UrlReporter({
 
 const requestReporter = new RequestReporter(config.request, {
   dryRunMode: true,
-  communication,
+  onMessageReady: (msg) => {
+    console.log(
+      '%c[DRY-RUN] request-reporter message ready:',
+      'color: green; font-size: 30px;',
+      msg,
+    );
+  },
   countryProvider: urlReporter.countryProvider,
   trustedClock: communication.trustedClock,
   getBrowserInfo: () => ({ name: 'xx' }),

--- a/reporting/src/communication-proxy/attrack-message-handler.js
+++ b/reporting/src/communication-proxy/attrack-message-handler.js
@@ -1,0 +1,85 @@
+/**
+ * WhoTracks.Me
+ * https://whotracks.me/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import logger from '../logger';
+import { requireParam, requireString } from '../utils';
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const ATTRACK_JOB_TYPE = 'attrack:send-message:v1';
+
+export default class AttrackMessageHandler {
+  constructor({ communication, jobScheduler }) {
+    this.communication = requireParam(communication);
+    this.jobScheduler = requireParam(jobScheduler);
+
+    this._configOverride = {
+      'wtm.attrack.tokensv2': {
+        readyIn: { min: 2 * SECOND, max: 4 * HOUR },
+      },
+      'wtm.attrack.keysv2': {
+        readyIn: { min: 2 * SECOND, max: 4 * HOUR },
+      },
+      'wtm.attrack.tp_events': {
+        readyIn: { min: 2 * SECOND, max: 30 * MINUTE },
+      },
+    };
+
+    this.jobScheduler.registerHandler(
+      ATTRACK_JOB_TYPE,
+      async (job) => {
+        const { message } = job.args;
+        requireParam(message);
+        requireString(message.action);
+
+        await this.communication.send(message);
+      },
+      {
+        priority: -1000,
+        cooldownInMs: 1 * SECOND,
+        maxJobsTotal: 500,
+        maxTTL: 14 * DAY,
+      },
+    );
+  }
+
+  sendInBackground(message) {
+    requireParam(message);
+    requireString(message.action);
+
+    if (this.jobScheduler.active) {
+      const job = {
+        type: ATTRACK_JOB_TYPE,
+        args: { message },
+        config: this._configOverride[message.action] || {},
+      };
+      this.jobScheduler.registerJob(job).catch((e) => {
+        logger.warn('Failed to register job', job, e);
+        this._sendNowInBackground(message);
+      });
+    } else {
+      // Sending directly has the advantage that the request reporter
+      // can be used even if the URL reporter is not available.
+      // It should happen rarely enough.
+      logger.info('jobScheduler not available. Send immediately...');
+      this._sendNowInBackground(message);
+    }
+  }
+
+  _sendNowInBackground(message) {
+    this.communication.send(message).catch((e) => {
+      logger.error('Failed to send message', e);
+    });
+  }
+}

--- a/reporting/src/job-scheduler.js
+++ b/reporting/src/job-scheduler.js
@@ -304,7 +304,7 @@ export default class JobScheduler {
     // "min" value and an optional "max" value (if you want randomness).
     //
     // Examples:
-    // - { min: 2000} will delay by (at least) 2 seconds
+    // - { min: 2000 } will delay by (at least) 2 seconds
     // - { min: 2000, max: 3000 } will delay by (at least) 2-3 seconds
     //
     // Note: the real delay can be higher, since there is no guarantee

--- a/reporting/src/request/index.js
+++ b/reporting/src/request/index.js
@@ -47,7 +47,7 @@ export default class RequestReporter {
     {
       trustedClock,
       countryProvider,
-      communication,
+      onMessageReady,
       getBrowserInfo,
       onTrackerInteraction = (event, state) => {
         logger.info('Tracker', event, 'with url:', state.url);
@@ -57,7 +57,7 @@ export default class RequestReporter {
     },
   ) {
     this.settings = settings;
-    this.communication = communication;
+    this.onMessageReady = onMessageReady;
     this.trustedClock = trustedClock;
     this.countryProvider = countryProvider;
     this.onTrackerInteraction = onTrackerInteraction;
@@ -150,11 +150,6 @@ export default class RequestReporter {
   }
 
   telemetry(message) {
-    if (!this.communication) {
-      logger.error('No provider provider loaded');
-      return;
-    }
-
     message.type = 'wtm.request';
     message.userAgent = this.userAgent;
     message.ts = this.trustedClock.getTimeAsYYYYMMDD();
@@ -168,8 +163,7 @@ export default class RequestReporter {
     message.payload.ctry = this.countryProvider.getSafeCountryCode();
 
     logger.debug('report', message);
-
-    this.communication.send(message);
+    this.onMessageReady(message);
   }
 
   /** Global module initialisation.

--- a/reporting/test/request/index.spec.js
+++ b/reporting/test/request/index.spec.js
@@ -97,6 +97,7 @@ describe('request/index', function () {
         configUrl: 'http://cdn',
         remoteWhitelistUrl: 'http://cdn',
         localWhitelistUrl: '/base/assets/request',
+        messageSender: () => {},
       },
       {
         countryProvider: {},


### PR DESCRIPTION
Provide a function to send anti-tracking messages through the job scheduler.

It is intended to smooth out the traffic during peaks like the begin of a new day, where all clients generate keysv2/tokensv2 messages. Also, having randomized client-side delays for tp_events introduces the possibility of message reordering, which is intended.