### PR TITLE
Request: fix unload

### DIFF
--- a/reporting/src/request/index.js
+++ b/reporting/src/request/index.js
@@ -251,9 +251,9 @@ export default class RequestReporter {
 
   unload() {
     this.ready = false;
-    if (this.qs_whitelist) {
-      this.qs_whitelist.destroy();
-    }
+
+    this.config.unload();
+
     if (this.cookieContext) {
       this.cookieContext.unload();
     }


### PR DESCRIPTION
In the actual (background page restart) unload scenario there is no way to perform async operation so touching storage wont work.
In the soft unload scenario, config should clean its timers.  