### PR TITLE
Remove browserInfoProvider dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "@cliqz/url-parser": "^1.1.5",
+        "bowser": "^2.11.0",
         "date-fns": "^2.29.3",
         "idb": "^7.1.1",
         "linkedom": "^0.18.10",
@@ -2005,6 +2006,12 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "idb": "^7.1.1",
     "linkedom": "^0.18.10",
     "pako": "^2.1.0",
-    "tldts-experimental": "^6.0.11"
+    "tldts-experimental": "^6.0.11",
+    "bowser": "^2.11.0"
   }
 }

--- a/reporting/example/index.js
+++ b/reporting/example/index.js
@@ -89,7 +89,6 @@ const urlReporter = new UrlReporter({
   storage: createStorage(),
   connectDatabase: createStorage,
   communication,
-  browserInfoProvider: async () => ({ browser: 'test' }),
 });
 
 const requestReporter = new RequestReporter(config.request, {

--- a/reporting/snapshots/0001/snapshot.json
+++ b/reporting/snapshots/0001/snapshot.json
@@ -1619,7 +1619,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -3251,7 +3251,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tokensv2",
@@ -3272,7 +3272,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3462,7 +3462,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3652,7 +3652,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3678,7 +3678,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3704,7 +3704,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3730,7 +3730,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3756,7 +3756,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3782,7 +3782,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3808,7 +3808,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3834,7 +3834,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3860,6 +3860,6 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   }
 ]

--- a/reporting/snapshots/0002/snapshot.json
+++ b/reporting/snapshots/0002/snapshot.json
@@ -1108,7 +1108,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -2225,7 +2225,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tokensv2",
@@ -2246,7 +2246,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2272,7 +2272,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2298,7 +2298,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2324,7 +2324,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2350,7 +2350,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2376,7 +2376,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2402,7 +2402,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2428,7 +2428,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2454,7 +2454,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2480,7 +2480,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -2506,6 +2506,6 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   }
 ]

--- a/reporting/snapshots/0003/snapshot.json
+++ b/reporting/snapshots/0003/snapshot.json
@@ -196,7 +196,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -398,7 +398,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tokensv2",
@@ -419,7 +419,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -609,7 +609,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -799,6 +799,6 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   }
 ]

--- a/reporting/snapshots/0004/snapshot.json
+++ b/reporting/snapshots/0004/snapshot.json
@@ -183,7 +183,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -369,7 +369,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tokensv2",
@@ -390,7 +390,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -572,7 +572,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -754,6 +754,6 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   }
 ]

--- a/reporting/snapshots/0005/snapshot.json
+++ b/reporting/snapshots/0005/snapshot.json
@@ -130,7 +130,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -252,7 +252,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -693,7 +693,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1142,7 +1142,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1275,7 +1275,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1397,7 +1397,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1838,7 +1838,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -2287,7 +2287,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tokensv2",
@@ -2308,7 +2308,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -4590,7 +4590,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -6876,7 +6876,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -6902,7 +6902,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -6928,6 +6928,6 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   }
 ]

--- a/reporting/snapshots/0006/snapshot.json
+++ b/reporting/snapshots/0006/snapshot.json
@@ -111,7 +111,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -237,7 +237,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -408,7 +408,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -526,7 +526,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1006,7 +1006,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1120,7 +1120,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1246,7 +1246,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1417,7 +1417,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -1535,7 +1535,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tp_events",
@@ -2015,7 +2015,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.tokensv2",
@@ -2036,7 +2036,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -3734,7 +3734,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -5432,7 +5432,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -5458,7 +5458,7 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   },
   {
     "action": "wtm.attrack.keysv2",
@@ -5484,6 +5484,6 @@
     },
     "ts": "",
     "type": "wtm.request",
-    "userAgent": "xx"
+    "userAgent": ""
   }
 ]

--- a/reporting/src/reporting.js
+++ b/reporting/src/reporting.js
@@ -38,13 +38,7 @@ import { BloomFilter } from './bloom-filters';
 const SECOND = 1000;
 
 export default class Reporting {
-  constructor({
-    config,
-    storage,
-    communication,
-    connectDatabase,
-    browserInfoProvider,
-  }) {
+  constructor({ config, storage, communication, connectDatabase }) {
     // Defines whether Reporting is fully initialized and has permission
     // to collect data.
     this.isActive = false;
@@ -152,7 +146,6 @@ export default class Reporting {
     });
 
     const aliveMessageGenerator = new AliveMessageGenerator({
-      browserInfoProvider,
       quorumChecker: this.quorumChecker,
       storage,
       storageKey: 'alive_config',

--- a/reporting/test/alive-message-generator.spec.js
+++ b/reporting/test/alive-message-generator.spec.js
@@ -18,18 +18,15 @@ describe('#AliveMessageGenerator', function () {
   const anotherHour = '2024030804';
 
   const storageKey = 'some-storage-key';
-  let browserInfoProvider;
   let navigatorApi;
   let quorumChecker;
   let storage;
   let uut;
 
-  let _browserInfo;
   let _shouldPassQuorum;
 
   function newAliveMessageGenerator() {
     return new AliveMessageGenerator({
-      browserInfoProvider,
       navigatorApi,
       quorumChecker,
       storage,
@@ -37,8 +34,8 @@ describe('#AliveMessageGenerator', function () {
     });
   }
 
-  // Helper that simulate an event like a restart of the service worker/background script:
-  // it keeps the storage but purges everything that was in memory.
+  // Helper that simulates an event like a restart of the service worker/background script:
+  // it keeps the storage, but purges everything that was in memory.
   async function simulateRestart() {
     uut = newAliveMessageGenerator();
   }
@@ -52,16 +49,11 @@ describe('#AliveMessageGenerator', function () {
   }
 
   beforeEach(() => {
-    _browserInfo = {
-      browser: 'Firefox',
-      version: '122',
-      os: 'Linux',
-      language: 'en-US',
-    };
     navigatorApi = {
+      userAgent:
+        'Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0',
       language: 'en-US',
     };
-    browserInfoProvider = async () => _browserInfo;
 
     quorumChecker = {
       _incCalls: 0,
@@ -154,19 +146,17 @@ describe('#AliveMessageGenerator', function () {
     runGenericTests();
 
     it('should share the config', async function () {
-      _browserInfo = {
-        browser: 'Firefox',
-        version: '122.1',
-        os: 'Linux',
-        language: 'en-US',
-      };
+      navigatorApi.userAgent =
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36';
       navigatorApi.language = 'de-DE';
 
       const message = await uut.generateMessage('de', '2024010203');
       expect(message).to.eql({
-        browser: 'Firefox',
-        version: '122', // only major version
+        browser: 'Chrome',
+        version: '138', // only major version
         os: 'Linux',
+        platform: 'desktop',
+        engine: 'Blink',
         language: 'de-DE', // from window.navigator
         ctry: 'de',
         t: '2024010203',
@@ -184,6 +174,8 @@ describe('#AliveMessageGenerator', function () {
         browser: '',
         version: '',
         os: '',
+        platform: '',
+        engine: '',
         language: '',
         ctry: '--',
         t: '2024010203',

--- a/reporting/test/reporting.spec.js
+++ b/reporting/test/reporting.spec.js
@@ -45,7 +45,6 @@ describe('#Reporting', function () {
       storage,
       communication,
       connectDatabase,
-      browserInfoProvider: async () => ({ browser: 'test' }),
     });
   });
 

--- a/reporting/test/request/index.spec.js
+++ b/reporting/test/request/index.spec.js
@@ -103,7 +103,6 @@ describe('request/index', function () {
         countryProvider: {},
         trustedClock,
         communication: {},
-        getBrowserInfo: () => ({ name: 'xx' }),
       },
     );
     await attrack.init();

--- a/reporting/test/request/index.test.js
+++ b/reporting/test/request/index.test.js
@@ -106,7 +106,6 @@ describe('RequestReporter', function () {
           communicationEmitter.emit('send', msg);
         },
         trustedClock,
-        getBrowserInfo: () => ({ name: 'xx' }),
         countryProvider: { getSafeCountryCode: () => 'en' },
       });
       await reporter.init();


### PR DESCRIPTION
Remove "browserInfoProvider":
* Handle browser detection for alive-messages as an implementation detail of the urlReporter. Also, include platform (e.g. "desktop") and engine (e.g. "Blink") in the message.
* Removed also from the requestReporter. For backward, the values are mapped to the original values. With the difference that Safari is additionally detected, but the Ghostery browser is removed.