### PR TITLE
Error recovery

### DIFF
--- a/reporting/test/helpers/in-memory-job-scheduler.js
+++ b/reporting/test/helpers/in-memory-job-scheduler.js
@@ -66,8 +66,14 @@ export async function runClockUntilJobQueueIsEmpty(
     }
   }
 
+  // To ensure that initialization is completed. Otherwise, job
+  // registrations may still be hanging.
+  await clock.runAllAsync();
+
   let iter = 0;
-  while (jobScheduler.getTotalJobs() > jobScheduler.getTotalJobsInDlq()) {
+  while (
+    jobScheduler.getTotalJobs() > jobScheduler.getTotalJobsWaitingForRetry()
+  ) {
     iter += 1;
     if (iter > maxIterations) {
       throw new Error(`Exceeded maximum steps (steps=${maxIterations})`);


### PR DESCRIPTION
Retry mechanism for recoverable jobs
* Jobs are placed in a "retryable" queue. If a job of the same type
succeeds, one job from that queue will be put into the "ready" queue.
* By default, jobs will be dropped after they failed three times. Jobs that
failed with an unclassified or permanent error will never be retried.