### PR TITLE
Guarantee deterministic key orders in messages with nested payloads

### DIFF
--- a/communication/src/utils.js
+++ b/communication/src/utils.js
@@ -13,20 +13,21 @@
  * Use case: when running object through JSON.stringify, it
  * should not be distinguishable in which order the object keys
  * where added.
- *
- * Note: The current implement only operates on the first level.
- * In our context, that should be suffient, since
- * anonymous-communication will not add nested structures.
- * The only nested structure is the payload, which means the
- * message creator will be responsible for the ordering.
- *
- * Should that become a burden, we could extend this function
- * to recursively sort the object keys.
  */
 export function sortObjectKeys(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
   const sortByKeys = (x, y) => {
     if (x[0] === y[0]) return 0;
     return x[0] < y[0] ? -1 : 1;
   };
-  return Object.fromEntries(Object.entries(obj).sort(sortByKeys));
+  return Object.fromEntries(
+    Object.entries(obj)
+      .sort(sortByKeys)
+      .map(([k, v]) => [k, sortObjectKeys(v)]),
+  );
 }

--- a/communication/test/utils.spec.js
+++ b/communication/test/utils.spec.js
@@ -41,6 +41,80 @@ describe('#sortObjectKeys', function () {
     );
   });
 
+  describe('should handle primitive values', function () {
+    for (const x of [
+      true,
+      false,
+      undefined,
+      null,
+      0,
+      1,
+      1.23,
+      '',
+      'foo',
+      // not primitive, but include:
+      [],
+      {},
+    ]) {
+      it(`- <<${x}>>`, function () {
+        const { x: xAfter } = sortObjectKeys({ x });
+        expect(xAfter).to.eql(x);
+      });
+
+      it(`- [${x}]`, function () {
+        const { x: xAfter } = sortObjectKeys({ x: [x] });
+        expect(xAfter).to.eql([x]);
+      });
+    }
+  });
+
+  it('should sort keys in nested structures', function () {
+    const obj1 = {
+      payload: {
+        paused: false,
+        mode: 'default',
+      },
+    };
+    const obj2 = {
+      payload: {
+        mode: 'default',
+        paused: false,
+      },
+    };
+
+    const obj1Json = JSON.stringify(sortObjectKeys(obj1));
+    const obj2Json = JSON.stringify(sortObjectKeys(obj2));
+    expect(obj1Json).to.eql(obj2Json);
+  });
+
+  it('should sort numeric-string keys in numeric order', function () {
+    const obj = {
+      payload: {
+        r: {
+          '11': { foo: 42, bar: null },
+          '10': { foo: 42, bar: null },
+          '2': { foo: 42, bar: null },
+          '1': { foo: 42, bar: null },
+          '0': { foo: 42, bar: null },
+        },
+      },
+    };
+    const objJson = JSON.stringify(sortObjectKeys(obj));
+
+    const expectedJson = JSON.stringify({
+      payload: {
+        r: {
+          '0': { bar: null, foo: 42 },
+          '1': { bar: null, foo: 42 },
+          '2': { bar: null, foo: 42 },
+          '10': { bar: null, foo: 42 },
+          '11': { bar: null, foo: 42 },
+        },
+      },
+    });
+    expect(objJson).to.eql(expectedJson);
+  });
+
   it('should support object with "toString" property', function () {
     // Note: used to throw (found by QuickCheck)
     const obj1 = {


### PR DESCRIPTION
Enforces a deterministic key ordering for messages like `wtm.popularity`.