### PR TITLE
Better handling of unicode text

### DIFF
--- a/reporting/src/popularity-vote-sanitizer.js
+++ b/reporting/src/popularity-vote-sanitizer.js
@@ -83,6 +83,12 @@ function sanitizePart(str) {
           str,
         );
         decodedStr = undefined;
+      } else if (hasInvalidSurrogates(decodedStr)) {
+        logger.warn(
+          'Ignoring edge case where the decoded string contains invalid surrogates',
+          str,
+        );
+        decodedStr = undefined;
       }
     } catch {
       // ignore (not well formed)
@@ -200,6 +206,10 @@ function maskHashes(str) {
 
   for (let size = str.length; size >= MIN_SIZE_TO_BE_MASKED; size -= 1) {
     for (let start = str.length - size; start >= 0; start -= 1) {
+      if (splitsSurrogatePair(str, start)) {
+        // would result in broken encodings
+        continue;
+      }
       const substring = str.slice(start, start + size);
       if (shouldBeMasked(substring)) {
         let prefix = '';
@@ -310,6 +320,45 @@ function skipHashDetection(str) {
   }
 
   return false;
+}
+
+function isHighSurrogate(code) {
+  return (code & 0xfc00) === 0xd800;
+}
+
+function isLowSurrogate(code) {
+  return (code & 0xfc00) === 0xdc00;
+}
+
+function hasInvalidSurrogates(str) {
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (isHighSurrogate(code)) {
+      if (!isLowSurrogate(str.charCodeAt(i + 1))) {
+        // high surrogate must be followed by a low surrogate
+        return true;
+      }
+      i++; // skip the low surrogate (already validated)
+    } else if (isLowSurrogate(code)) {
+      // low surrogate without a preceding high surrogate
+      return true;
+    }
+  }
+  return false;
+}
+
+// If we split an UTF-16 string in the middle of a surrogate pair,
+// it results in broken text. This function detects it.
+function splitsSurrogatePair(str, pos) {
+  if (pos <= 0 || pos >= str.length) {
+    // spliting at the start or end can never break
+    return false;
+  }
+
+  return (
+    isHighSurrogate(str.charCodeAt(pos - 1)) &&
+    isLowSurrogate(str.charCodeAt(pos))
+  );
 }
 
 // visible for testing

--- a/reporting/src/popularity-vote-sanitizer.js
+++ b/reporting/src/popularity-vote-sanitizer.js
@@ -212,7 +212,10 @@ function maskHashes(str) {
 
   for (let size = str.length; size >= MIN_SIZE_TO_BE_MASKED; size -= 1) {
     for (let start = str.length - size; start >= 0; start -= 1) {
-      if (splitsSurrogatePair(str, start)) {
+      if (
+        splitsSurrogatePair(str, start) ||
+        splitsSurrogatePair(str, start + size)
+      ) {
         // would result in broken encodings
         continue;
       }

--- a/reporting/src/popularity-vote-sanitizer.js
+++ b/reporting/src/popularity-vote-sanitizer.js
@@ -110,7 +110,13 @@ function sanitizePart(str) {
 // Phase 2: text is fixed, but not yet truncated.
 function sanitizePart__fixedButNotYetTruncated__(str) {
   if (str.length >= MAX_TEXT_LENGTH) {
-    const truncated = str.slice(0, MAX_TEXT_LENGTH - MASKED.length);
+    let splitAt = MAX_TEXT_LENGTH - MASKED.length;
+    if (splitsSurrogatePair(str, splitAt)) {
+      // avoid splitting between a unicode pair, since it will result in broken text
+      splitAt -= 1;
+    }
+
+    const truncated = str.slice(0, splitAt);
     logger.debug('Truncating long text segment:', str, '->', truncated);
     const sanitized = sanitizePart__fixedText__(truncated);
     return sanitized.endsWith(MASKED) ? sanitized : sanitized + MASKED;

--- a/reporting/test/popularity-vote-sanitizer.spec.js
+++ b/reporting/test/popularity-vote-sanitizer.spec.js
@@ -543,7 +543,11 @@ describe('#sanitizePathSegment', function () {
   });
 
   describe('should not crash on arbitrary URL path segments', function () {
-    for (const segment of ['%F0%90%80%80%F0%90%80%82%F0%90%A0%81IbFe']) {
+    for (const segment of [
+      '%F0%90%80%80%F0%90%80%82%F0%90%A0%81IbFe',
+      'b---344%F0%9F%90%80%F0%9F%90%818880-88e',
+      '01-%F0%9F%90%80-687%F0%9F%90%80ca%F0%9F%90%80-%F0%9F%90%80b-0245',
+    ]) {
       it(`- <<${segment}>>`, function () {
         sanitizePathSegment(segment); // should not throw
       });

--- a/reporting/test/popularity-vote-sanitizer.spec.js
+++ b/reporting/test/popularity-vote-sanitizer.spec.js
@@ -542,6 +542,14 @@ describe('#sanitizePathSegment', function () {
     }
   });
 
+  describe('should not crash on arbitrary URL path segments', function () {
+    for (const segment of ['%F0%90%80%80%F0%90%80%82%F0%90%A0%81IbFe']) {
+      it(`- <<${segment}>>`, function () {
+        sanitizePathSegment(segment); // should not throw
+      });
+    }
+  });
+
   describe('[property based testing]', function () {
     it('should only remove, but never add characters', function () {
       fc.assert(

--- a/reporting/test/popularity-vote-sanitizer.spec.js
+++ b/reporting/test/popularity-vote-sanitizer.spec.js
@@ -550,26 +550,56 @@ describe('#sanitizePathSegment', function () {
     }
   });
 
+  describe('should safely truncate long strings', function () {
+    // %F0%9F%90%80 decodes to U+1F400, which JavaScript stores as the
+    // surrogate pair '🐀' (two UTF-16 code units). By growing
+    // the prefix one char at a time, we eventually reach a length at
+    // which the internal truncation at MAX_TEXT_LENGTH - MASKED.length
+    // lands between the high and low surrogate of that pair. The
+    // truncated text then carries a lone surrogate, which
+    // `encodeURIComponent` rejects with "URI malformed" once the
+    // backport step runs.
+    it('should not throw when a surrogate pair straddles the truncation boundary', function () {
+      for (let i = 0; i < 300; i++) {
+        sanitizePathSegment('a'.repeat(i) + '%F0%9F%90%80aaa');
+      }
+    });
+  });
+
   describe('[property based testing]', function () {
+    function checkSanitizedPathSegment(pathSegment) {
+      const sanitized = sanitizePathSegment(pathSegment);
+      if (!sanitized.includes('#??#')) {
+        return sanitized === pathSegment;
+      }
+      if (sanitized.length > pathSegment.length) {
+        return false;
+      }
+      const nonMasked = sanitized.replaceAll('#??#', '');
+      return textCanBeDerivedByRemovingChars({
+        fullText: pathSegment,
+        reducedTo: nonMasked,
+      });
+    }
+
     it('should only remove, but never add characters', function () {
       fc.assert(
         fc.property(fc.webUrl(), (url) => {
           const { pathname } = new URL(url);
           for (const pathSegment of pathname.split('/').filter((x) => x)) {
-            const sanitized = sanitizePathSegment(pathSegment);
-            if (!sanitized.includes('#??#')) {
-              return sanitized === pathSegment;
-            }
-            if (sanitized.length > pathSegment.length) {
-              return false;
-            }
-            const nonMasked = sanitized.replaceAll('#??#', '');
-            return textCanBeDerivedByRemovingChars({
-              fullText: pathSegment,
-              reducedTo: nonMasked,
-            });
+            return checkSanitizedPathSegment(pathSegment);
           }
         }),
+      );
+    });
+
+    it('should handle arbitrary, long strings', function () {
+      fc.assert(
+        fc.property(
+          fc.string({ unit: 'binary', minLength: 1, maxLength: 2000 }),
+          checkSanitizedPathSegment,
+        ),
+        { numRuns: 5 },
       );
     });
   });


### PR DESCRIPTION
Detect some cases where splitting the string will break it (splitting in-between unicode chars)