### PR TITLE
Also reject mask candidates whose end splits a surrogate pair

### DIFF
--- a/reporting/src/popularity-vote-sanitizer.js
+++ b/reporting/src/popularity-vote-sanitizer.js
@@ -212,8 +212,12 @@ function maskHashes(str) {
 
   for (let size = str.length; size >= MIN_SIZE_TO_BE_MASKED; size -= 1) {
     for (let start = str.length - size; start >= 0; start -= 1) {
-      if (splitsSurrogatePair(str, start)) {
-        // would result in broken encodings
+      if (
+        splitsSurrogatePair(str, start) ||
+        splitsSurrogatePair(str, start + size)
+      ) {
+        // either boundary lands inside a surrogate pair; the resulting
+        // slice would carry a lone surrogate that breaks encodeURIComponent
         continue;
       }
       const substring = str.slice(start, start + size);

--- a/reporting/test/popularity-vote-sanitizer.spec.js
+++ b/reporting/test/popularity-vote-sanitizer.spec.js
@@ -543,7 +543,15 @@ describe('#sanitizePathSegment', function () {
   });
 
   describe('should not crash on arbitrary URL path segments', function () {
-    for (const segment of ['%F0%90%80%80%F0%90%80%82%F0%90%A0%81IbFe']) {
+    for (const segment of [
+      '%F0%90%80%80%F0%90%80%82%F0%90%A0%81IbFe',
+      // Two adjacent percent-encoded surrogate pairs feeding maskHashes.
+      // Without an end-boundary check, maskHashes may select a substring
+      // whose end falls between a high and low surrogate, and the lone
+      // low surrogate then survives into encodeURIComponent.
+      'b---344%F0%9F%90%80%F0%9F%90%818880-88e',
+      '01-%F0%9F%90%80-687%F0%9F%90%80ca%F0%9F%90%80-%F0%9F%90%80b-0245',
+    ]) {
       it(`- <<${segment}>>`, function () {
         sanitizePathSegment(segment); // should not throw
       });
@@ -600,6 +608,34 @@ describe('#sanitizePathSegment', function () {
           checkSanitizedPathSegment,
         ),
         { numRuns: 5 },
+      );
+    });
+
+    // Many real URLs contain percent-encoded astral characters (emoji,
+    // historic scripts, etc.), which decode into UTF-16 surrogate pairs.
+    // This generator concentrates on that mix of percent encodings,
+    // ASCII letters and digits, and dashes — the conditions under which
+    // the masking pipeline previously produced lone surrogates.
+    it('should handle inputs rich in percent-encoded surrogate pairs', function () {
+      const surrogatePairEncodings = fc.constantFrom(
+        '%F0%9F%90%80', // 🐀 U+1F400
+        '%F0%9F%90%81', // 🐁 U+1F401
+        '%F0%90%80%80', // U+10000
+        '%F0%90%A0%81', // U+10801
+      );
+      const fragment = fc.oneof(
+        surrogatePairEncodings,
+        fc.constantFrom('a', 'b', 'c', 'd', 'e', 'f', '-'),
+        fc.integer({ min: 0, max: 9 }).map(String),
+      );
+      fc.assert(
+        fc.property(
+          fc
+            .array(fragment, { minLength: 1, maxLength: 50 })
+            .map((xs) => xs.join('')),
+          checkSanitizedPathSegment,
+        ),
+        { numRuns: 200 },
       );
     });
   });


### PR DESCRIPTION
## Summary
- Closes the remaining "URI malformed" crash path that survives PR #201's surrogate-pair guard.
- `maskHashes` now skips candidates whose **end** boundary lands inside a surrogate pair, not only the start. Without this, the trailing slice (`str.slice(start + size)`) could begin with a lone low surrogate and crash `encodeURIComponent` inside `backportMaskToOriginalText`.
- Adds two minimal regression cases and a property test focused on percent-encoded astral characters — the regime where this bug lives. The existing `numRuns: 5` arbitrary-binary property test was too thin to surface it.

## Test plan
- [ ] Visit a URL whose path segment contains adjacent percent-encoded surrogate pairs (e.g. emoji or historic-script characters mixed with hex/dashes), verify the popularity-vote pipeline does not throw and the sanitized output is still a subsequence of the input.
- [ ] Visit a URL whose path segment contains a single percent-encoded astral character surrounded by digits, verify masking still occurs where appropriate.