### PR TITLE
Request reporter: fix cookie checks, clean up dead code

### DIFF
--- a/reporting/src/request/config.js
+++ b/reporting/src/request/config.js
@@ -28,7 +28,6 @@ const DEFAULTS = {
   cookieEnabled: true,
   qsEnabled: true,
   sendAntiTrackingHeader: true,
-  // tpDomainDepth: 2,
   cookieMode: COOKIE_MODE.THIRD_PARTY,
 };
 

--- a/reporting/src/request/index.js
+++ b/reporting/src/request/index.js
@@ -76,7 +76,6 @@ export default class RequestReporter {
     }
     this.dryRunMode = dryRunMode;
     this.VERSION = VERSION;
-    this.LOG_KEY = 'attrack';
     this.debug = false;
     this.recentlyModified = new TempSet();
     this.whitelistedRequestCache = new Set();
@@ -158,14 +157,6 @@ export default class RequestReporter {
 
   isQSEnabled() {
     return this.config.qsEnabled;
-  }
-
-  isFingerprintingEnabled() {
-    return this.config.fingerprintEnabled;
-  }
-
-  isReferrerEnabled() {
-    return this.config.referrerEnabled;
   }
 
   telemetry(message) {
@@ -322,10 +313,7 @@ export default class RequestReporter {
     if (checkValidContext(state) === false) {
       return response.toWebRequestResponse();
     }
-    // oAuthDetector.checkMainFrames
-    if (this.oAuthDetector.checkMainFrames(state) === false) {
-      return response.toWebRequestResponse();
-    }
+    this.oAuthDetector.checkMainFrames(state);
     // checkIsMainDocument
     if (!state.isMainFrame === false) {
       return response.toWebRequestResponse();

--- a/reporting/src/request/qs-whitelist2.js
+++ b/reporting/src/request/qs-whitelist2.js
@@ -216,10 +216,6 @@ export default class QSWhitelist2 {
     return this.bloomFilter.testSingle(`t${token}`);
   }
 
-  isUnsafeKey() {
-    return false;
-  }
-
   addSafeKey(domain, key) {
     if (!this.localSafeKey[domain]) {
       this.localSafeKey[domain] = {};

--- a/reporting/src/request/steps/cookie-context.js
+++ b/reporting/src/request/steps/cookie-context.js
@@ -108,7 +108,7 @@ export default class CookieContext {
     const sourceHost = state.tabUrlParts.hostname;
     const requestHost = state.urlParts.hostname;
     const key = `${sourceHost}:${requestHost}`;
-    if (this.config.cookieTrustReferers && this.trustedThirdParties.has(key)) {
+    if (this.trustedThirdParties.has(key)) {
       const trustCounter = this.trustedThirdParties.get(key);
       trustCounter.c += 1;
       trustCounter.ts = Date.now();
@@ -120,15 +120,11 @@ export default class CookieContext {
   }
 
   checkVisitCache(state) {
-    // check if the response has been received yet
     const stage = state.statusCode !== undefined ? 'set_cookie' : 'cookie';
     const tabId = state.tabId;
-    const diff =
-      Date.now() - (this.visitCache.get(`${tabId}:${state.hostGD}`) || 0);
-    if (
-      diff < TIME_ACTIVE &&
-      this.visitCache.get(`${tabId}:${state.sourceGD}`)
-    ) {
+    const hostGD = state.urlParts.generalDomain;
+    const lastVisit = this.visitCache.get(`${tabId}:${hostGD}`) || 0;
+    if (Date.now() - lastVisit < TIME_ACTIVE) {
       state.incrementStat(`${stage}_allow_visitcache`);
       return false;
     }

--- a/reporting/src/request/steps/token-examiner.js
+++ b/reporting/src/request/steps/token-examiner.js
@@ -31,7 +31,6 @@ export default class TokenExaminer {
       storageKey: 'wtm-request-reporting:token-examiner:request-key-value',
     });
     this._syncTimer = null;
-    this._lastPrune = null;
   }
 
   async init() {
@@ -121,7 +120,6 @@ export default class TokenExaminer {
             this.qsWhitelist.addSafeKey(
               tracker,
               this.hashTokens ? key : md5(key),
-              this.config.safekeyValuesThreshold,
             );
           }
           return hash;
@@ -129,7 +127,7 @@ export default class TokenExaminer {
 
       // push updated cache
       this.requestKeyValue.set(tracker, newTrackerMap);
-      this._scheduleSync(today !== this._lastPrune);
+      this._scheduleSync();
       return true;
     }
     return true;
@@ -171,7 +169,6 @@ export default class TokenExaminer {
           this.qsWhitelist.addSafeKey(
             tracker,
             this.hashTokens ? key : md5(key),
-            Object.keys(tokenSet).length,
           );
           this.removeRequestKeyValueEntry(tracker, key);
         }

--- a/reporting/src/request/steps/token-telemetry/index.js
+++ b/reporting/src/request/steps/token-telemetry/index.js
@@ -168,8 +168,6 @@ export default class TokenTelemetry {
 
     const keyTokens = state.urlParts.extractKeyValues().params;
     if (keyTokens.length > 0) {
-      // const truncatedDomain = truncateDomain(state.urlParts.host, this.config.tpDomainDepth);
-      // const domain = md5(truncatedDomain).substr(0, 16);
       const firstParty = truncatedHash(state.tabUrlParts.generalDomain);
       const generalDomain = truncatedHash(state.urlParts.generalDomain);
 

--- a/reporting/src/request/utils/time.js
+++ b/reporting/src/request/utils/time.js
@@ -11,30 +11,16 @@
 
 /* eslint prefer-template: 'off' */
 
-// this is the sanitised timestamp retrieved from humanweb.
-let hwTs = null;
-
 /** Get datetime string of the current hour in the format YYYYMMDDHH
  */
 export function getTime() {
   const date = new Date();
-  const ts = hwTs;
-  let _ts;
-  let h = null;
-  if (!ts) {
-    let d = null;
-    let m = null;
-    let y = null;
-    d = (date.getDate() < 10 ? '0' : '') + date.getDate();
-    m = (date.getMonth() < 9 ? '0' : '') + parseInt(date.getMonth() + 1, 10);
-    h = (date.getUTCHours() < 10 ? '0' : '') + date.getUTCHours();
-    y = date.getFullYear();
-    _ts = y + '' + m + '' + d + '' + h;
-  } else {
-    h = (date.getUTCHours() < 10 ? '0' : '') + date.getUTCHours();
-    _ts = ts + '' + h;
-  }
-  return _ts;
+  const d = (date.getDate() < 10 ? '0' : '') + date.getDate();
+  const m =
+    (date.getMonth() < 9 ? '0' : '') + parseInt(date.getMonth() + 1, 10);
+  const h = (date.getUTCHours() < 10 ? '0' : '') + date.getUTCHours();
+  const y = date.getFullYear();
+  return y + '' + m + '' + d + '' + h;
 }
 
 export function newUTCDate() {

--- a/reporting/test/request/steps/cookie-context.test.js
+++ b/reporting/test/request/steps/cookie-context.test.js
@@ -1,0 +1,189 @@
+/**
+ * WhoTracks.Me
+ * https://ghostery.com/whotracksme
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import chrome from 'sinon-chrome';
+import { expect } from 'chai';
+
+import CookieContext from '../../../src/request/steps/cookie-context.js';
+import { parse } from '../../../src/utils/url.js';
+
+function mockState({
+  tabId = 1,
+  url = 'https://tracker.test/pixel.gif',
+  tabUrl = 'https://source.test/page',
+  isMainFrame = false,
+  statusCode,
+  referrer,
+} = {}) {
+  const stats = {};
+  return {
+    tabId,
+    url,
+    urlParts: parse(url),
+    tabUrl,
+    tabUrlParts: parse(tabUrl),
+    isMainFrame,
+    statusCode,
+    stats,
+    incrementStat(key) {
+      stats[key] = (stats[key] || 0) + 1;
+    },
+    getReferrer() {
+      return referrer;
+    },
+  };
+}
+
+describe('CookieContext', function () {
+  let cookieContext;
+  let qsWhitelist;
+
+  before(function () {
+    chrome.storage.session = chrome.storage.local;
+    globalThis.chrome = chrome;
+  });
+
+  beforeEach(async function () {
+    chrome.flush();
+    chrome.storage.session.get.yields({});
+    qsWhitelist = {
+      isTrackerDomain: () => false,
+    };
+    cookieContext = new CookieContext({}, qsWhitelist);
+    await cookieContext.init();
+  });
+
+  afterEach(function () {
+    cookieContext.unload();
+  });
+
+  after(function () {
+    chrome.flush();
+    delete globalThis.chrome;
+  });
+
+  describe('checkVisitCache', function () {
+    it('returns true when the visit cache is empty', function () {
+      const state = mockState();
+      expect(cookieContext.checkVisitCache(state)).to.equal(true);
+    });
+
+    it('returns false when the third-party domain has a recent visit-cache entry for this tab', function () {
+      const state = mockState({
+        tabId: 7,
+        url: 'https://tracker.test/pixel.gif',
+        tabUrl: 'https://source.test/page',
+      });
+      cookieContext.visitCache.set(
+        `${state.tabId}:${state.urlParts.generalDomain}`,
+        Date.now(),
+      );
+      expect(cookieContext.checkVisitCache(state)).to.equal(false);
+      expect(state.stats.cookie_allow_visitcache).to.equal(1);
+    });
+
+    it('uses the set_cookie stat prefix when statusCode is set', function () {
+      const state = mockState({
+        tabId: 7,
+        statusCode: 200,
+      });
+      cookieContext.visitCache.set(
+        `${state.tabId}:${state.urlParts.generalDomain}`,
+        Date.now(),
+      );
+      expect(cookieContext.checkVisitCache(state)).to.equal(false);
+      expect(state.stats.set_cookie_allow_visitcache).to.equal(1);
+    });
+
+    it('returns true when the cached entry is older than TIME_ACTIVE (20s)', function () {
+      const state = mockState({ tabId: 7 });
+      cookieContext.visitCache.set(
+        `${state.tabId}:${state.urlParts.generalDomain}`,
+        Date.now() - 21 * 1000,
+      );
+      expect(cookieContext.checkVisitCache(state)).to.equal(true);
+    });
+
+    it('returns true when the cache entry belongs to a different tab', function () {
+      const state = mockState({ tabId: 7 });
+      cookieContext.visitCache.set(
+        `99:${state.urlParts.generalDomain}`,
+        Date.now(),
+      );
+      expect(cookieContext.checkVisitCache(state)).to.equal(true);
+    });
+  });
+
+  describe('checkCookieTrust', function () {
+    it('returns true when the trust map is empty', function () {
+      const state = mockState();
+      expect(cookieContext.checkCookieTrust(state)).to.equal(true);
+    });
+
+    it('returns false when the (sourceHost:requestHost) pair is in the trust map', function () {
+      const state = mockState({
+        url: 'https://tracker.test/x',
+        tabUrl: 'https://source.test/page',
+      });
+      const key = `${state.tabUrlParts.hostname}:${state.urlParts.hostname}`;
+      cookieContext.trustedThirdParties.set(key, { c: 0, ts: Date.now() });
+
+      expect(cookieContext.checkCookieTrust(state)).to.equal(false);
+      expect(state.stats.cookie_allow_trust).to.equal(1);
+    });
+
+    it('uses the set_cookie stat prefix when statusCode is set', function () {
+      const state = mockState({ statusCode: 200 });
+      const key = `${state.tabUrlParts.hostname}:${state.urlParts.hostname}`;
+      cookieContext.trustedThirdParties.set(key, { c: 0, ts: Date.now() });
+
+      expect(cookieContext.checkCookieTrust(state)).to.equal(false);
+      expect(state.stats.set_cookie_allow_trust).to.equal(1);
+    });
+
+    it('increments the trust counter and refreshes the timestamp on each match', function () {
+      const state = mockState();
+      const key = `${state.tabUrlParts.hostname}:${state.urlParts.hostname}`;
+      const before = Date.now() - 10_000;
+      cookieContext.trustedThirdParties.set(key, { c: 0, ts: before });
+
+      cookieContext.checkCookieTrust(state);
+      cookieContext.checkCookieTrust(state);
+
+      const counter = cookieContext.trustedThirdParties.get(key);
+      expect(counter.c).to.equal(2);
+      expect(counter.ts).to.be.greaterThan(before);
+    });
+  });
+
+  describe('assignCookieTrust → checkCookieTrust integration', function () {
+    it('a referrer-driven main-frame request makes subsequent third-party requests trusted', function () {
+      qsWhitelist.isTrackerDomain = () => false;
+      const mainFrameState = mockState({
+        tabId: 7,
+        url: 'https://tracker.test/landing',
+        tabUrl: 'https://source.test/page',
+        isMainFrame: true,
+        referrer: 'https://source.test/page',
+      });
+
+      cookieContext.assignCookieTrust(mainFrameState);
+
+      const subRequestState = mockState({
+        tabId: 7,
+        url: 'https://tracker.test/cookie-pixel',
+        tabUrl: 'https://source.test/page',
+      });
+      expect(cookieContext.checkCookieTrust(subRequestState)).to.equal(false);
+      expect(subRequestState.stats.cookie_allow_trust).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Restore two cookie allow-list exceptions in the request reporter that were silent no-ops since the original anti-tracking import: `checkVisitCache` (referenced never-set `state.hostGD`/`state.sourceGD`) and `checkCookieTrust` (gated on a never-set `cookieTrustReferers` config flag). Cookies for legitimately user-initiated cross-domain interactions are now allowed as originally intended.
- Remove dead code across `reporting/src/request/`: unused methods (`isUnsafeKey`, `isFingerprintingEnabled`, `isReferrerEnabled`), unused fields (`LOG_KEY`, `_lastPrune`), an unreachable `else` branch in `getTime()`, ignored extra arguments at `addSafeKey` call sites, a dead `=== false` check on `oAuthDetector.checkMainFrames`, and several commented-out lines.
