### PR TITLE
Remove Safari workaround

### DIFF
--- a/reporting/src/job-scheduler.js
+++ b/reporting/src/job-scheduler.js
@@ -847,18 +847,10 @@ export default class JobScheduler {
 
   async _writeJobsToDisk() {
     this._clearAutoFlushTimer();
-
-    // [Experiment] Potential workaround for a Safari bug:
-    // * we see indicators that Safari corrupts the data when there
-    //   are concurrent write operation to chrome.storage.local
-    // * as a mitigation, serialize the writes now
-    this._writeToDiskExecutor ||= new SeqExecutor();
-    return this._writeToDiskExecutor.run(async () =>
-      this.storage.set(this.storageKey, {
-        dbVersion: DB_VERSION,
-        jobQueues: this.jobQueues,
-      }),
-    );
+    return this.storage.set(this.storageKey, {
+      dbVersion: DB_VERSION,
+      jobQueues: this.jobQueues,
+    });
   }
 
   /**


### PR DESCRIPTION
Revert "Follow-up: experiment with sequentializing writes to work around a potential (#187)"

This reverts commit 1be73536af9a493b496701570161e7a423c50350.

The data corruption in Safari is afterwards lower but not gone. On other platforms, it is not needed anyway.

refs https://github.com/whotracksme/webextension-packages/pull/185 refs https://github.com/whotracksme/webextension-packages/pull/187