### PR TITLE
page signal: improved double-fetch

### DIFF
--- a/reporting/src/doublefetch-page-handler.js
+++ b/reporting/src/doublefetch-page-handler.js
@@ -10,7 +10,7 @@
  */
 
 import logger from './logger';
-import { requireParam, lazyInitAsync } from './utils';
+import { requireParam, requireInt, lazyInitAsync } from './utils';
 import { randomBetween } from './random';
 import { BadJobError } from './errors';
 import { anonymousHttpGet } from './http';
@@ -44,6 +44,50 @@ function isSubSequence({ sequence, subsequence }) {
     j++;
   }
   return i === subsequence.length;
+}
+
+export function toTrustedUrl(url, { baseUrl, log, logWarn }) {
+  if (!url) {
+    return null;
+  }
+
+  if (!baseUrl.startsWith('https://')) {
+    logWarn('baseUrl must be an absolute URL (and https only):', baseUrl);
+    return null;
+  }
+  if (!url.startsWith('https://') && !url.startsWith('/')) {
+    // note: relative URL without a leading '/' are technically possible,
+    // but uncommon enough that we can ignore. If we handle them, it is
+    // opening more possibilities of false-positives.
+    log('URL must either absolute or relative with a leading /', url);
+    return null;
+  }
+
+  let from;
+  try {
+    from = new URL(baseUrl);
+  } catch (e) {
+    logWarn('Invalid baseUrl (possible but unexpected):', baseUrl);
+    return null;
+  }
+
+  let to;
+  try {
+    to = new URL(url, baseUrl);
+  } catch (e) {
+    log('Ignore invalid url:', url);
+    return null;
+  }
+
+  if (from.origin !== to.origin) {
+    log('origin mismatch found:', baseUrl, '->', url);
+    return null;
+  }
+
+  // Normalization (https://example.test/foo#123 => https://example.test/foo).
+  // We are looking for the most simple version of the URL
+  to.hash = '';
+  return to.toString();
 }
 
 /**
@@ -132,6 +176,107 @@ export function titlesMatchAfterDoublefetch({
   }
 
   return false;
+}
+
+// Conservative list of "@type" fields that related only to the current website.
+// In other words, types that are purely navigational should not be listed.
+// Same with types that related to other entities like the organization or
+// information about the author.
+//
+// Note: Schema.org is not forced, but it is the most common vocabulary by far.
+// Thus a good starting point to extend coverage, is its documentation:
+// https://schema.org/docs/full.html
+const URL_RELATED_JSONLD_TYPES = new Set([
+  // Schema.org
+  'article', // covers a relatively common typo (should be "Article")
+  'Article',
+  'BackgroundNewsArticle',
+  'NewsArticle',
+  'BlogPosting',
+  'PodcastEpisode',
+  'ReportageNewsArticle',
+  'ScholarlyArticle',
+  'TechArticle',
+  'VideoObject',
+  'WebPage',
+]);
+
+export function findAlternativeUrlInJsonLD(jsonld) {
+  const { '@type': type, '@id': url } = jsonld;
+  if (!url || !type || !url.startsWith('https://')) return null;
+  return URL_RELATED_JSONLD_TYPES.has(type) ? url : null;
+}
+
+export function aggregateMetaDataInJsonLD(jsonldArray) {
+  const matches = [];
+
+  for (const jsonld of jsonldArray) {
+    const { '@type': type, '@context': context } = jsonld;
+    if (context !== 'http://schema.org' && context !== 'https://schema.org') {
+      continue;
+    }
+    if (!URL_RELATED_JSONLD_TYPES.has(type)) {
+      continue;
+    }
+
+    const content = {};
+    for (const key of [
+      'dateCreated',
+      'dateModified',
+      'datePublished',
+      'uploadDate',
+      'duration',
+    ]) {
+      if (jsonld[key]) {
+        content[key] = jsonld[key];
+      }
+    }
+    if (Object.keys(content).length > 0) {
+      content.type = type;
+    }
+    matches.push(content);
+  }
+  if (matches.length === 0) {
+    return {};
+  }
+
+  // The first always wins, but we can try to merge information
+  // from other entries as long as they are not conflicting.
+  // It is rare, a use case are entries that are duplicated, but
+  // the second entry has extra fields.
+  let result = matches.shift();
+  for (const other of matches) {
+    if (
+      Object.entries(result).every(
+        ([key, value]) => (other[key] || value) === value,
+      )
+    ) {
+      for (const [key, value] of Object.entries(other)) {
+        result[key] ||= value;
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Heuristic to reject text that is clearly not a timestamp.
+ * It does not have to be extremely precise.
+ */
+export function looksLikeSafeTimestamp(str) {
+  if (typeof str !== 'string') return false;
+  if (str.length < 4 || str.length > 40) return false;
+  return !isNaN(new Date(str));
+}
+
+export function looksLikeSafeDuration(str) {
+  if (typeof str !== 'string') return false;
+  if (str.length > 20) return false;
+
+  // ISO 8601 durations (https://en.wikipedia.org/wiki/ISO_8601#Durations)
+  return /^P(?!$)(\d+Y)?(\d+M)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/.test(
+    str,
+  );
 }
 
 /**
@@ -264,12 +409,16 @@ export default class DoublefetchPageHandler {
     if (!preDoublefetch) {
       throw new BadJobError('preDoublefetch missing');
     }
-    const canonicalUrl = preDoublefetch?.meta?.canonicalUrl;
-    const canonicalUrlDiffers = canonicalUrl && canonicalUrl !== url;
 
     const pageFetcher = this.pageFetcherProvider();
     const log = logger.debug.bind(logger.debug, `[doublefetch=${url}]`);
     const logWarn = logger.warn.bind(logger.warn, `[doublefetch=${url}]`);
+    const withBaseUrl = (baseUrl) => ({ baseUrl, log, logWarn });
+    const canonicalUrl = toTrustedUrl(
+      preDoublefetch?.meta?.canonicalUrl,
+      withBaseUrl(url),
+    );
+    const canonicalUrlDiffers = canonicalUrl && canonicalUrl !== url;
 
     try {
       // shared error handling when testing alternative URLs (e.g. canonical URLs)
@@ -286,7 +435,16 @@ export default class DoublefetchPageHandler {
         }
       };
 
-      const checkUrl = async (urlToTest, { isCanonicalUrl }) => {
+      const checkUrl = async (urlToTest, { isCanonicalUrl, level = 0 }) => {
+        if (requireInt(level) >= 3) {
+          // By design, there should be at most two recursion steps:
+          // - level: 0 (initial call) [may recurse]
+          // - level: 1 (test discovered candidates) [only new JSON-LD candidates may recurse]
+          // - level: 2 (reachable by deep JSON-LD candidate) [may NOT recurse]
+          // - level: 3 (unreachable and indicates a bug)
+          throw new Error('exceeded maximum recursion level');
+        }
+
         if (await this.newPageApprover.mightBeMarkedAsPrivate(urlToTest)) {
           return { ok: false, details: 'marked as private in bloom filter' };
         }
@@ -297,31 +455,49 @@ export default class DoublefetchPageHandler {
           return { ok: false, details: rejectReason };
         }
 
-        const canonicalUrl2 = pageStructure?.meta?.canonicalUrl;
-        if (canonicalUrl2) {
-          if (!isCanonicalUrl && urlToTest === canonicalUrl2) {
+        // Also consider alternative URLs that we just discovered.
+        // If we found a canonical URL, we want to try it immediately,
+        // even before the actual URL that we want to test (urlToTest).
+        //
+        // Note: There are more canidates (e.g. JSON-LD), but these
+        // will be delayed and only tested with the actual URL fails.
+        const canonicalUrlCandidate = toTrustedUrl(
+          pageStructure.meta?.canonicalUrl,
+          withBaseUrl(urlToTest),
+        );
+        if (canonicalUrlCandidate) {
+          if (!isCanonicalUrl && urlToTest === canonicalUrlCandidate) {
             log(
               'Found a matching canonical URL in doublefetch result for URL:',
               urlToTest,
             );
             isCanonicalUrl = true;
-          } else if (urlToTest === url && canonicalUrl2 !== canonicalUrl) {
+          } else if (
+            urlToTest === url &&
+            canonicalUrlCandidate !== canonicalUrl
+          ) {
+            // We detected a potential canonical URL, but since it does not
+            // match our original URL, we cannot confirm yet. If it does not
+            // work, ignore it and continue.
             log(
               'Updated canonical URL from',
               canonicalUrl,
-              'to',
-              canonicalUrl2,
+              'to the candidate',
+              canonicalUrlCandidate,
             );
             try {
-              const result = await checkUrl(canonicalUrl2, {
+              const result = await checkUrl(canonicalUrlCandidate, {
                 isCanonicalUrl: true,
+                level: level + 1,
               });
               if (result.ok) {
+                log('Confirmed candidate:', canonicalUrlCandidate);
                 return result;
               }
             } catch (e) {
-              await markAsPrivateOrRethrowToRetry(canonicalUrl2, e);
+              await markAsPrivateOrRethrowToRetry(canonicalUrlCandidate, e);
             }
+            log('Candidate did not work:', canonicalUrlCandidate);
           }
         }
 
@@ -332,6 +508,44 @@ export default class DoublefetchPageHandler {
           log,
         });
         if (!accept) {
+          // Now that the actual URL failed, try other alternative URLs.
+          // JSON-LD may include candidates, but they are less trustworthy.
+          const mayUseJsonLD = !isCanonicalUrl || level <= 1;
+          if (mayUseJsonLD && pageStructure?.meta?.jsonld?.length > 0) {
+            for (const jsonld of pageStructure.meta.jsonld) {
+              const bestMatch = findAlternativeUrlInJsonLD(jsonld);
+              const jsonldCandidateUrl = toTrustedUrl(
+                bestMatch,
+                withBaseUrl(urlToTest),
+              );
+              if (
+                jsonldCandidateUrl &&
+                jsonldCandidateUrl !== canonicalUrl &&
+                jsonldCandidateUrl !== urlToTest
+              ) {
+                log(
+                  'Structure did not match, but try a candidate from JSON-LD instead:',
+                  jsonldCandidateUrl,
+                );
+                try {
+                  const result = await checkUrl(jsonldCandidateUrl, {
+                    isCanonicalUrl: true,
+                    level: level + 1,
+                  });
+                  if (result.ok) {
+                    log('Confirmed candidate:', jsonldCandidateUrl);
+                    return result;
+                  }
+                } catch (e) {
+                  await markAsPrivateOrRethrowToRetry(jsonldCandidateUrl, e);
+                }
+                log('JSON-LD candidate did not work:', jsonldCandidateUrl);
+                break; // stop after checking one candidate
+              }
+            }
+          }
+
+          // No luck with the alternative URLs either. Give up.
           return { ok: false, details };
         }
 
@@ -339,6 +553,7 @@ export default class DoublefetchPageHandler {
           page,
           doublefetchUrl: urlToTest,
           isCanonicalUrl,
+          doublefetchPageStructure: pageStructure,
           log,
           logWarn,
         });
@@ -348,9 +563,14 @@ export default class DoublefetchPageHandler {
         return { ok: true, safePage };
       };
 
+      // Test URLs in this order:
+      // 1. Canonical URL (if it exists and differs from the original URL)
+      // 2. Original URL
+      // 3. Discovered alternative URLs (will trigger recursive calls)
       let safePage;
       if (canonicalUrlDiffers) {
         try {
+          // step 1: canonical URL
           const result = await checkUrl(canonicalUrl, { isCanonicalUrl: true });
           if (result.ok) {
             safePage = result.safePage;
@@ -361,6 +581,7 @@ export default class DoublefetchPageHandler {
       }
 
       if (!safePage) {
+        // step 2: original URL
         const isCanonicalUrl = url === canonicalUrl;
         const result = await checkUrl(url, { isCanonicalUrl });
         if (result.ok) {
@@ -397,9 +618,9 @@ export default class DoublefetchPageHandler {
     const accept = () => ({ accept: true });
     const discard = (reason) => ({ accept: false, details: reason });
 
-    if (before.noindex !== false) {
+    if (before.noindex !== false && page.pageLoadMethod === 'full-page-load') {
       logger.warn(
-        'noindex pages should have been filtered out already:',
+        'noindex pages should have been filtered out already (it was a full-page-load):',
         before,
       );
       return discard('noindex must be false (before)');
@@ -442,32 +663,61 @@ export default class DoublefetchPageHandler {
       }
     }
 
-    if (
-      !titlesMatchAfterDoublefetch({
-        before: page.title,
-        after: after.title,
-      })
-    ) {
+    // Now, confirm the title, or more precise the "page title".
+    // There are three types of titles:
+    // 1) "page title": the title from the tab API (should be what the user saw)
+    // 2) "DOM title": the title in the "page-structure" (before doublefetch)
+    // 3) "doublefetch title(s)": again, extract by "page-structure", but not from
+    //    the real document, but from the parsed HTML *after* a doublefetch request.
+    //
+    // Candidates for the "doublefetch title":
+    // There is always the main title (typically <title>...</title>), but
+    // we can safely try fallback like "og:title" (Open Graph Meta Tags).
+    const doublefetchTitles = [after.title];
+    if (after?.meta?.og?.title && after.meta.og.title !== after.title) {
+      doublefetchTitles.push(after.meta.og.title);
+    }
+
+    const confirmTitle = (before) =>
+      doublefetchTitles.some((after) =>
+        titlesMatchAfterDoublefetch({ before, after }),
+      );
+
+    // Always confirm the "page title" (it will be part of the message)
+    if (!confirmTitle(page.title)) {
       return discard(
-        `titles do not match the page title: <<${page.title}>> ==> <<${after.title}>>`,
+        `no match for the 'page title' (tab API): <<${
+          page.title
+        }>> ==> ${JSON.stringify(doublefetchTitles)}`,
       );
     }
+
+    // When a page gets loaded, the "page title" and "DOM title" should generally match.
+    // But for single-page applications, it is possible that the "DOM title" gets outdated,
+    // because the content may not be fully updated during the history navigations.
+    // This is why this step needs to be optional (to avoid false-negatives).
     if (
       page.pageLoadMethod !== 'history-navigation' &&
-      !titlesMatchAfterDoublefetch({
-        before: before.title,
-        after: after.title,
-      })
+      !confirmTitle(before.title)
     ) {
       return discard(
-        `titles do not match the meta title: <<${before.title}>> ==> <<${after.title}>>`,
+        `no match for the 'DOM title' (extracted via 'page-structure'): <<${
+          before.title
+        }>> ==> ${JSON.stringify(doublefetchTitles)}`,
       );
     }
 
     return accept();
   }
 
-  _sanitizePage({ page, doublefetchUrl, isCanonicalUrl, log, logWarn }) {
+  _sanitizePage({
+    page,
+    doublefetchUrl,
+    isCanonicalUrl,
+    doublefetchPageStructure,
+    log,
+    logWarn,
+  }) {
     const safePage = {
       url: doublefetchUrl,
       title: page.title,
@@ -561,6 +811,34 @@ export default class DoublefetchPageHandler {
     if (page.ref) {
       safePage.ref = maskUrl(page.ref);
     }
+
+    if (doublefetchPageStructure.meta?.jsonld?.length > 0) {
+      const { type, ...safeFields } = aggregateMetaDataInJsonLD(
+        doublefetchPageStructure.meta.jsonld,
+      );
+      if (type) {
+        safePage.jsonld = { type };
+
+        // timestamps
+        for (const key of [
+          'dateCreated',
+          'dateModified',
+          'datePublished',
+          'uploadDate',
+        ]) {
+          const timestamp = safeFields[key];
+          if (looksLikeSafeTimestamp(timestamp)) {
+            safePage.jsonld[key] = timestamp;
+          }
+        }
+
+        // durations (currently only the field "duration")
+        if (looksLikeSafeDuration(safeFields.duration)) {
+          safePage.jsonld.duration = safeFields.duration;
+        }
+      }
+    }
+
     return safePage;
   }
 

--- a/reporting/src/doublefetch-page-handler.js
+++ b/reporting/src/doublefetch-page-handler.js
@@ -272,6 +272,20 @@ export default class DoublefetchPageHandler {
     const logWarn = logger.warn.bind(logger.warn, `[doublefetch=${url}]`);
 
     try {
+      // shared error handling when testing alternative URLs (e.g. canonical URLs)
+      const markAsPrivateOrRethrowToRetry = async (failedUrl, e) => {
+        if (e.isPermanentError) {
+          logWarn(
+            'Alternative URL failed permanently, so mark it as private:',
+            failedUrl,
+            e,
+          );
+          await this._tryMarkAsPrivate(failedUrl);
+        } else {
+          throw e;
+        }
+      };
+
       const checkUrl = async (urlToTest, { isCanonicalUrl }) => {
         if (await this.newPageApprover.mightBeMarkedAsPrivate(urlToTest)) {
           return { ok: false, details: 'marked as private in bloom filter' };
@@ -306,17 +320,7 @@ export default class DoublefetchPageHandler {
                 return result;
               }
             } catch (e) {
-              if (e.isPermanentError) {
-                logWarn(
-                  'Failed to process (corrected) canonical URL',
-                  canonicalUrl2,
-                  '(falling back to original URL now)',
-                  e,
-                );
-                await this._tryMarkAsPrivate(canonicalUrl2);
-              } else {
-                throw e;
-              }
+              await markAsPrivateOrRethrowToRetry(canonicalUrl2, e);
             }
           }
         }
@@ -352,17 +356,7 @@ export default class DoublefetchPageHandler {
             safePage = result.safePage;
           }
         } catch (e) {
-          if (e.isPermanentError) {
-            logWarn(
-              'Failed to process canonical URL',
-              canonicalUrl,
-              '(falling back to original URL now)',
-              e,
-            );
-            await this._tryMarkAsPrivate(canonicalUrl);
-          } else {
-            throw e;
-          }
+          await markAsPrivateOrRethrowToRetry(canonicalUrl, e);
         }
       }
 

--- a/reporting/src/page-quorum-check-handler.js
+++ b/reporting/src/page-quorum-check-handler.js
@@ -11,10 +11,18 @@
 
 import logger from './logger';
 import { BadJobError } from './errors';
-import random from './random';
+import { random32Bit } from './random';
 
 function createPageMessage(safePage, ctry) {
-  const { url, title, ref = null, redirects = null, search, lang } = safePage;
+  const {
+    url,
+    title,
+    ref = null,
+    redirects = null,
+    jsonld,
+    search,
+    lang,
+  } = safePage;
   const { activity } = safePage.aggregator;
 
   const payload = {
@@ -35,14 +43,23 @@ function createPageMessage(safePage, ctry) {
     };
   }
 
+  // For now, only attach when present. The alternative would be to "null"
+  // it like "ref" and "redirects". But the semantic might be misleading,
+  // since a lack of "jsonld" does not imply that the page did not have
+  // JSON-LD meta data. Since we are conservative in detecting it, it is
+  // expected to see only limited coverage at this point.
+  if (jsonld) {
+    payload.jsonld = jsonld;
+  }
+
   // consider page messages as duplicates if "payload.url" is identical
   const deduplicateBy = 'url';
 
   const body = {
     action: 'wtm.page',
     payload,
-    ver: 3, // Note: no need to keep this number in sync among messages
-    'anti-duplicates': Math.floor(random() * 10000000),
+    ver: 4, // Note: no need to keep this number in sync among messages
+    'anti-duplicates': random32Bit(),
   };
   return { body, deduplicateBy };
 }

--- a/reporting/src/page-structure.js
+++ b/reporting/src/page-structure.js
@@ -54,7 +54,6 @@ export async function analyzePageStructure(doc) {
           requestedIndex ||
           tags.includes('all') ||
           tags.includes('index') ||
-          tags.includes('index') ||
           tags.includes('max-image-preview:large') ||
           tags.includes('max-image-preview:standard') ||
           tags.includes('max-video-preview:-1');
@@ -93,16 +92,82 @@ export async function analyzePageStructure(doc) {
     return og;
   }
 
+  function sanitizeJsonLdField(text) {
+    if (typeof text === 'string') {
+      const text_ = text.trim();
+      if (text_.length <= 2048) {
+        return text_;
+      }
+    }
+    return null;
+  }
+
+  // parse JSON-LD (https://json-ld.org/)
+  function parseJsonLd(doc) {
+    const jsonld = [];
+    for (const elem of doc.querySelectorAll(
+      'script[type="application/ld+json"]',
+    )) {
+      let parsedJson;
+      try {
+        parsedJson = JSON.parse(elem.textContent);
+
+        // 1) some websites put the content in a '@graph' array, for instance:
+        // {
+        //   "@context": "https://schema.org",
+        //   "@graph": [
+        //     {<0>},
+        //     {<1>},
+        //   ]
+        // }
+        // ==> lift "@graph" to the top-level
+        if (
+          typeof parsedJson['@context'] === 'string' &&
+          Array.isArray(parsedJson['@graph']) &&
+          Object.keys(parsedJson).length === 2
+        ) {
+          for (const elem of parsedJson['@graph']) {
+            elem['@context'] ||= parsedJson['@context'];
+          }
+          parsedJson = parsedJson['@graph'];
+        }
+
+        // 2) some websites use arrays, some split it across multiple scripts
+        // ==> everything becomes an array
+        parsedJson = Array.isArray(parsedJson) ? parsedJson : [parsedJson];
+      } catch (e) {
+        continue; // ignore broken JSON
+      }
+      for (const json of parsedJson) {
+        const entry = {};
+        for (const key of [
+          '@context',
+          '@type',
+          '@id',
+          'url',
+          'name',
+          'headline',
+          'duration',
+          'dateCreated',
+          'dateModified',
+          'datePublished',
+          'uploadDate',
+        ]) {
+          const value = sanitizeJsonLdField(json[key]);
+          if (value) {
+            entry[key] = value;
+          }
+        }
+        jsonld.push(entry);
+      }
+    }
+    return jsonld;
+  }
+
   doc = doc || document;
 
   try {
     const { noindex, requestedIndex } = parseMetaRobotTags(doc);
-    if (noindex) {
-      return {
-        noindex: true,
-      };
-    }
-
     const title = getTitle(doc);
     const url = doc.URL;
 
@@ -113,6 +178,7 @@ export async function analyzePageStructure(doc) {
     const contentType = doc.contentType || null;
     const language = parseHtmlLangAttribute(doc);
     const og = parseOpenGraphMetaTags(doc);
+    const jsonld = parseJsonLd(doc);
 
     return {
       title,
@@ -122,8 +188,9 @@ export async function analyzePageStructure(doc) {
         language,
         contentType,
         og,
+        jsonld,
       },
-      noindex: false,
+      noindex,
       requestedIndex,
     };
   } catch (e) {

--- a/reporting/src/pagedb.js
+++ b/reporting/src/pagedb.js
@@ -441,10 +441,15 @@ export default class PageDB {
       return reject('incomplete information: page not fully loaded');
     }
 
-    // check static heuristics
-    if (page.preDoublefetch.noindex) {
+    // "noindex" pages can be immediately dropped unless we detected history
+    //  navigations, because the meta information might be stale.
+    if (
+      page.preDoublefetch.noindex &&
+      page.pageLoadMethod !== 'history-navigation'
+    ) {
       return rejectForever('marked as noindex');
     }
+
     if (page.search && page.search.depth === 0) {
       return rejectForever('ignore search engine result pages');
     }

--- a/reporting/test/doublefetch-page-handler.spec.js
+++ b/reporting/test/doublefetch-page-handler.spec.js
@@ -20,6 +20,11 @@ import {
 import DoublefetchPageHandler, {
   titlesMatchAfterDoublefetch,
   sanitizeActivity,
+  toTrustedUrl,
+  findAlternativeUrlInJsonLD,
+  aggregateMetaDataInJsonLD,
+  looksLikeSafeTimestamp,
+  looksLikeSafeDuration,
 } from '../src/doublefetch-page-handler.js';
 
 class JobSchedulerMock {
@@ -205,6 +210,107 @@ describe('DoublefetchPageHandler', function () {
         canonicalUrl: null,
       });
     });
+
+    it('should check not only the title in <title>, but also og:title (Open Graph Protocol title)', async function () {
+      const page = {
+        aggregator: {
+          firstSeenAt: 1778263491203,
+          lastSeenAt: 1778263491206,
+          lastWrittenAt: 1778263562547,
+          activity: 0.0645025,
+        },
+        url: 'https://www.twitch.tv/sieglinde',
+        status: 'complete',
+        pageLoadMethod: 'history-navigation',
+        title: 'Sieglinde - Twitch',
+        preDoublefetch: {
+          meta: {
+            canonicalUrl: 'https://www.twitch.tv/sieglinde',
+            contentType: 'text/html',
+            jsonld: [
+              {
+                '@context': 'http://schema.org',
+                '@type': 'VideoObject',
+                name: 'Sieglinde - Twitch',
+                uploadDate: '2026-06-02T06:06:04Z',
+              },
+            ],
+            language: 'en-US',
+            og: {
+              image:
+                'https://static-cdn.jtvnw.net/jtv_user_pictures/ab1ba65f-22a9-45a4-9455-50807c03e8d1-profile_image-300x300.png',
+              title: 'Sieglinde - Twitch',
+              url: 'https://www.twitch.tv/sieglinde',
+              video:
+                'https://player.twitch.tv/?channel=sieglinde&player=facebook&autoplay=true&parent=meta.tag',
+            },
+          },
+          noindex: false,
+          requestedIndex: true,
+          title: 'sieglinde - Twitch',
+          url: 'https://www.twitch.tv/sieglinde',
+          lastUpdatedAt: 1778263491202,
+        },
+        lastUpdatedAt: 1778263491204,
+        lang: 'en',
+      };
+
+      // The original page title (tab API) was "Sieglinde - Twitch".
+      //
+      // Note that the DOM <title> changed after doublefetch from "sieglinde - Twitch"
+      // to "Twitch". "Twitch" alone would be not enough, but the Open Graph title (og:title)
+      // is "Sieglinde - Twitch", which still allows us to confirm the page title.
+      pageFetcherMock.reconfig({
+        'https://www.twitch.tv/sieglinde': {
+          title: 'Twitch',
+          meta: {
+            canonicalUrl: 'https://www.twitch.tv/sieglinde',
+            language: null,
+            contentType: null,
+            og: {
+              title: 'Sieglinde - Twitch',
+              url: 'https://www.twitch.tv/sieglinde',
+              image:
+                'https://static-cdn.jtvnw.net/jtv_user_pictures/ab1ba65f-22a9-45a4-9455-50807c03e8d1-profile_image-300x300.png',
+              video:
+                'https://player.twitch.tv/?channel=sieglinde&player=facebook&autoplay=true&parent=meta.tag',
+            },
+            jsonld: [
+              {
+                '@context': 'http://schema.org',
+                '@type': 'VideoObject',
+                name: 'Sieglinde - Twitch',
+                uploadDate: '2026-05-07T06:06:04Z',
+              },
+            ],
+          },
+          noindex: false,
+          requestedIndex: true,
+        },
+      });
+
+      const { ok, safePage } = await uut.runJob(page);
+
+      expect(ok).to.be.true;
+      pageFetcherMock.expectAllFetchedOnce();
+      relaxedSafePageEqual(safePage, {
+        url: 'https://www.twitch.tv/sieglinde',
+        title: 'Sieglinde - Twitch',
+        requestedIndex: true,
+        lang: {
+          html: 'en-US',
+          detect: 'en',
+        },
+        aggregator: {
+          activity: '0.0645',
+        },
+        canonicalUrl: 'https://www.twitch.tv/sieglinde',
+        jsonld: {
+          type: 'VideoObject',
+          uploadDate: '2026-05-07T06:06:04Z',
+        },
+      });
+    });
   });
 
   describe('when given a website with canonical URL', function () {
@@ -295,7 +401,7 @@ describe('DoublefetchPageHandler', function () {
     });
   });
 
-  describe('when a page indexed by search engine, has a canonical URL, and signals it wants to be shared', function () {
+  describe('when a page indexed by a search engine, has a canonical URL, and signals it wants to be shared', function () {
     it('should allow a safe Wikipedia page like https://de.wikipedia.org/wiki/J%C3%BCrgen_Klopp', async function () {
       const page = {
         aggregator: {
@@ -856,5 +962,192 @@ describe('#sanitizeActivity', function () {
         }),
       );
     });
+  });
+});
+
+describe('#toTrustedUrl', function () {
+  function withBaseUrl(baseUrl) {
+    const noop = () => {};
+    return { baseUrl, log: noop, logWarn: noop };
+  }
+
+  for (const { url, baseUrl, expected } of [
+    {
+      url: 'https://abc.test/foo',
+      baseUrl: 'https://abc.test/foo',
+      expected: 'https://abc.test/foo',
+    },
+    {
+      url: 'https://abc.test/keepme',
+      baseUrl: 'https://abc.test/ignore',
+      expected: 'https://abc.test/keepme',
+    },
+    {
+      url: 'https://abc.test/foo',
+      baseUrl: 'https://example.other/',
+      expected: null,
+    },
+    {
+      url: '/foo', // relative
+      baseUrl: 'https://abc.test/',
+      expected: 'https://abc.test/foo',
+    },
+    {
+      url: 'foo', // relative (non-leading '/')
+      baseUrl: 'https://abc.test/',
+      expected: null,
+    },
+    {
+      url: '{{ .og_url }}', // invalid
+      baseUrl: 'https://abc.test/',
+      expected: null,
+    },
+  ]) {
+    it(`url=${url} + baseUrl=${baseUrl} ==> ${expected}`, function () {
+      expect(toTrustedUrl(url, withBaseUrl(baseUrl))).to.eql(expected);
+    });
+  }
+});
+
+describe('#findAlternativeUrlInJsonLD', function () {
+  it('should detect use the "@id" for "VideoObject" types', function () {
+    expect(
+      findAlternativeUrlInJsonLD({
+        '@context': 'https://schema.org',
+        '@type': 'VideoObject',
+        '@id': 'https://www.youtube.com/watch?v=dNoTvg0t52c',
+        name: 'EPICA - Storm The Sorrow (Official video - HD remastered)',
+        uploadDate: '2012-04-24T04:55:09-07:00',
+      }),
+    ).to.eql('https://www.youtube.com/watch?v=dNoTvg0t52c');
+  });
+});
+
+describe('#aggregateMetaDataInJsonLD', function () {
+  it('should merge a duplicate entry that has extra fields', function () {
+    const entry1 = {
+      '@context': 'https://schema.org',
+      '@type': 'VideoObject',
+      '@id': 'https://www.youtube.com/watch?v=W-fFHeTX70Q',
+      name: 'The Best of Beethoven',
+      uploadDate: '2012-11-13T03:05:47-08:00',
+    };
+    const entry2 = {
+      ...entry1,
+      duration: 'PT5858S',
+    };
+
+    const expected = {
+      type: 'VideoObject',
+      uploadDate: '2012-11-13T03:05:47-08:00',
+      duration: 'PT5858S',
+    };
+
+    // the order does not matter
+    expect(aggregateMetaDataInJsonLD([entry1, entry2])).to.eql(expected);
+    expect(aggregateMetaDataInJsonLD([entry2, entry1])).to.eql(expected);
+
+    // ... we can also repeat it multiple times
+    expect(aggregateMetaDataInJsonLD([entry1, entry1, entry2])).to.eql(
+      expected,
+    );
+    expect(aggregateMetaDataInJsonLD([entry1, entry2, entry1])).to.eql(
+      expected,
+    );
+  });
+});
+
+describe('#looksLikeSafeTimestamp', function () {
+  function shouldAccept(str) {
+    if (!looksLikeSafeTimestamp(str)) {
+      expect.fail(`Expected to be accepted, but was rejected: <<${str}>>`);
+    }
+  }
+
+  function shouldReject(str) {
+    if (looksLikeSafeTimestamp(str)) {
+      expect.fail(`Expected to be rejected, but was accepted: <<${str}>>`);
+    }
+  }
+
+  it('should accept typical timestamps', function () {
+    shouldAccept('2024-01-15T12:34:56Z');
+    shouldAccept('2012-04-24T04:55:09-07:00');
+    shouldAccept('2026-02-01T08:55:42+00:00');
+    shouldAccept('2024-01-15');
+    shouldAccept('2021-10-07 05:14:11');
+  });
+
+  it('should reject uncommon formats', function () {
+    shouldReject('2026-03-31 15:37:45America/Sao_Paulo');
+  });
+
+  it('should reject non-strings', function () {
+    shouldReject(null);
+    shouldReject(undefined);
+    shouldReject(123);
+    shouldReject({});
+  });
+
+  it('should reject strings that are too short or too long', function () {
+    shouldReject('');
+    shouldReject('0');
+    shouldReject('1/1');
+    shouldReject('x'.repeat(128));
+  });
+
+  it('should reject strings that are clearly not timestamps', function () {
+    shouldReject('hello world');
+    shouldReject('not a date at all');
+  });
+});
+
+describe('#looksLikeSafeDuration', function () {
+  function shouldAccept(str) {
+    if (!looksLikeSafeDuration(str)) {
+      expect.fail(`Expected to be accepted, but was rejected: <<${str}>>`);
+    }
+  }
+
+  function shouldReject(str) {
+    if (looksLikeSafeDuration(str)) {
+      expect.fail(`Expected to be rejected, but was accepted: <<${str}>>`);
+    }
+  }
+
+  it('should accept typical ISO 8601 durations', function () {
+    shouldAccept('PT1H');
+    shouldAccept('PT15M');
+    shouldAccept('PT1H30M');
+    shouldAccept('PT1H30M45S');
+    shouldAccept('P1D');
+    shouldAccept('P1Y2M3DT4H5M6S');
+  });
+
+  it('should reject malformed durations', function () {
+    shouldReject('P');
+    shouldReject('PT');
+    shouldReject('1H');
+    shouldReject('P1H');
+    shouldReject('P1YT');
+    shouldReject('PT1X');
+  });
+
+  it('should reject values that are no durations', function () {
+    shouldReject('');
+    shouldReject('Duration');
+    shouldReject('Dauer');
+    shouldReject('Kesto');
+  });
+
+  it('should reject non-strings', function () {
+    shouldReject(null);
+    shouldReject(undefined);
+    shouldReject(123);
+    shouldReject({});
+  });
+
+  it('should reject strings that are too long', function () {
+    shouldReject('P' + '1Y'.repeat(20));
   });
 });


### PR DESCRIPTION
Improves double-fetch and adds limited support for JSON-LD.
    
The canononical URL is still the preferred alternative URL, but links from JSON-LD can be used as another source to fallback. In both cases, the URLs should be within the same hostname as the original.
    
Improved the support for single-page navigations:
 * fixed: the "noidex" flag could be overly conservative when the original page set it, but navigation to indexable pages where skipped later
* when matching the page title, it tries to confirm it also with alternatives (e.g. og:title).
