### PR TITLE
(tests only) Fix for rare "Exceeded maximum steps (steps=1000)"

### DIFF
--- a/reporting/test/helpers/in-memory-job-scheduler.js
+++ b/reporting/test/helpers/in-memory-job-scheduler.js
@@ -36,7 +36,7 @@ export async function runClockUntilJobQueueIsEmpty(
   async function advanceTo(ts) {
     const diff = ts - Date.now();
     if (diff > 0) {
-      await clock.tickAsync(diff);
+      await clock.tickAsync(Math.ceil(diff));
     }
   }
 


### PR DESCRIPTION
Subtle bug in the tests. The pitfall is that "clock.tickAsync" works with integers. Advancing values 0 < ... < 1 does not work.

Should fix errors like that:

```
  #PopularityVoteHandler
    #PopularityVoteHandler
      [property based testing]
        ✖ should not crash for arbitrary URLs
          Chrome Headless 149.0.0.0 (Linux 0.0.0)
        Property failed after 6 tests
        { seed: 153666539, path: "5", endOnFailure: true }
        Counterexample: ["http://y.ugn//","hostnamePath","4w",2]
        Shrunk 0 time(s)
        Got error: Exceeded maximum steps (steps=1000)
            at runClockUntilJobQueueIsEmpty (test/helpers/in-memory-job-scheduler.js:79:13 <- test/index.js:99376:15)
            at async expectExactlyTheseSignals (test/popularity-vote-handler.spec.js:171:7 <- test/index.js:102352:9)
            at async test/popularity-vote-handler.spec.js:345:17 <- test/index.js:102525:19
            at async AsyncProperty.run (node_modules/fast-check/lib/esm/check/property/AsyncProperty.generic.js:46:28 <- test/index.js:81485:30)
            at async asyncRunIt (node_modules/fast-check/lib/esm/check/runner/Runner.js:33:21 <- test/index.js:85262:23)
            at async Context.<anonymous> (test/popularity-vote-handler.spec.js:304:9 <- test/index.js:102485:11)
```